### PR TITLE
DIS-276 prevent user logout on network error

### DIFF
--- a/code/src/components/navigation.js
+++ b/code/src/components/navigation.js
@@ -234,6 +234,7 @@ export function App() {
                signOut: async () => {
                     await RemoveData().then((res) => {
                          //queryClient.invalidateQueries({});
+						 Sentry.captureMessage("User signed out");
                          updateUser([]);
                          dispatch({ type: 'SIGN_OUT' });
                     });

--- a/code/src/util/api/user.js
+++ b/code/src/util/api/user.js
@@ -63,18 +63,25 @@ export async function reloadProfile(url) {
      });
      const response = await discovery.post(`${endpoint.url}getPatronProfile`, postBody);
      if (response.ok) {
-          if (response.data.result) {
+          // any 2XX response will count, but may not be what we expect
+          if (response.data?.result) {
                //console.log(response.data.result.profile);
+               // if there is a result, this is good data
                if (response.data?.result?.profile) {
                     return response.data.result.profile;
                } else {
                     return response.data.result;
                }
+          // all other 'ok' responses that don't conform to expectations are a failure
+          } else {
+               return {
+                    success: false,
+               };
           }
+     // response was not 'ok', so throw an error
+     } else {
+          throw new Error(`error response from ${endpoint.url}getPatronProfile`);
      }
-     return {
-          success: false,
-     };
 }
 
 /**

--- a/code/src/util/logout.js
+++ b/code/src/util/logout.js
@@ -7,7 +7,7 @@ import { LOGIN_DATA } from './globals';
 import { LIBRARY } from './loadLibrary';
 import { PATRON } from './loadPatron';
 import { BrowseCategoryContext, LibraryBranchContext, LibrarySystemContext, UserContext } from '../context/initialContext';
-
+import * as Sentry from '@sentry/react-native';
 /**
  * Logout the user and clean up data
  **/
@@ -73,4 +73,5 @@ export async function RemoveData() {
      LOGIN_DATA.loadedInitialData = false;
      LOGIN_DATA.themeSaved = false;
      console.log('Storage data cleansed.');
+	 Sentry.captureMessage("Remove Data called");
 }


### PR DESCRIPTION
If Discovery is unreachable or returns a non-2XX status when the background refresh process executes (every 15 min in 25.02, every 5 in 25.03), the user session would be invalidated and the user would have to reauthenticate.

Now, an Error is thrown, which prevents calls to reloadProfile from executing onSuccess or .then() steps, which include the session invalidation call.  The user profile is not updated, but the authentication session persists