### PR TITLE
DIS-623: Open links on the More Page in an external browser

### DIFF
--- a/code/src/screens/More/More.js
+++ b/code/src/screens/More/More.js
@@ -1,6 +1,6 @@
-import * as WebBrowser from 'expo-web-browser';
 import { Box, Center, FlatList, HStack, Pressable, Text } from 'native-base';
 import React from 'react';
+import { Linking } from 'react-native';
 
 // custom components and helper files
 import { GLOBALS } from '../../util/globals';
@@ -30,7 +30,7 @@ export const MoreScreen = () => {
      ];
 
      const openWebsite = async (url) => {
-          WebBrowser.openBrowserAsync(url);
+          Linking.openURL(url);
      };
 
      const onPressMenuItem = (item) => {


### PR DESCRIPTION
Opening links in the more page with an external browser because expo's internal browser had issues with Wheaton's mobile print page and may have issues with other file upload dialogs in external sites.

Release notes to follow in an aspen-discovery PR