### PR TITLE
DIS-624: converting libraryId and autoPickUserHomeLocation into int

### DIFF
--- a/code/src/screens/Auth/LoginForm.js
+++ b/code/src/screens/Auth/LoginForm.js
@@ -165,7 +165,7 @@ export const GetLoginForm = (props) => {
           await SecureStore.setItemAsync('userKey', valueUser);
           await SecureStore.setItemAsync('secretKey', valueSecret);
           await AsyncStorage.setItem('@lastStoredVersion', Constants.expoConfig.version);
-          const autoPickUserHomeLocation = LIBRARY.appSettings?.autoPickUserHomeLocation ?? 0;
+          const autoPickUserHomeLocation = parseInt(LIBRARY.appSettings?.autoPickUserHomeLocation ?? 0);
 
           if (PATRON.homeLocationId && !_.includes(GLOBALS.slug, 'aspen-lida') && autoPickUserHomeLocation === 1) {
                console.log(PATRON.homeLocationId);

--- a/code/src/util/api/library.js
+++ b/code/src/util/api/library.js
@@ -50,6 +50,13 @@ export async function getLibraryInfo(url = null, id = null) {
      if (id) {
           libraryId = id;
      }
+	 if (typeof(libraryId) == "string")
+	 {
+		//strip quotes from libraryId
+		libraryId = libraryId.replace(/['"]+/g, '');
+		//then convert it into an int 
+		libraryId = parseInt(libraryId);
+	 }
 
      const discovery = create({
           baseURL: apiUrl + '/API',


### PR DESCRIPTION
to test:
* connect LiDA to a discovery with multiple locations per library
* make sure the instance is activated for a branded LiDA
* in the branded app settings check Use User Home Location When Logging In
* Log into your LiDA app and check more to see that you are connected to the proper location.