### PR TITLE
DIS-773: Display message while processing Scan and Go checkout

### DIFF
--- a/code/src/screens/SCO/SelfCheckOut.js
+++ b/code/src/screens/SCO/SelfCheckOut.js
@@ -184,7 +184,13 @@ export const SelfCheckOut = () => {
                <Heading fontSize="md" pb={2}>
                     {getTermFromDictionary(language, 'checked_out_during_session')}
                </Heading>
-               {isProcessingCheckout ? loadingSpinner() : <FlatList data={items} keyExtractor={(item, index) => index.toString()} ListEmptyComponent={currentCheckOutEmpty()} ListHeaderComponent={currentCheckoutHeader()} renderItem={({ item }) => currentCheckOutItem(item)} />}
+               {isProcessingCheckout ? (
+                   <Center>
+                        <Text pb={5}>{getTermFromDictionary(language, 'processing_checkout_message')}</Text>
+                        {loadingSpinner()}
+                   </Center>
+               ) : <FlatList data={items} keyExtractor={(item, index) => index.toString()} ListEmptyComponent={currentCheckOutEmpty()} ListHeaderComponent={currentCheckoutHeader()} renderItem={({ item }) => currentCheckOutItem(item)} />
+               }
                <Center pt={5}>
                     <Button onPress={() => finishSession()} colorScheme="primary" size="sm">
                          {getTermFromDictionary(language, 'button_finish')}

--- a/code/src/translations/defaults.json
+++ b/code/src/translations/defaults.json
@@ -601,5 +601,6 @@
   "call_number": "Call Number",
   "more_information": "More Info",
   "manage_language": "Preferred Language",
-  "manage_appearance": "Appearance"
+  "manage_appearance": "Appearance",
+  "processing_checkout_message": "Processing checkout - you can scan your next item"
 }

--- a/release-notes/25.06.00.MD
+++ b/release-notes/25.06.00.MD
@@ -9,4 +9,4 @@
 
 //katherine
 ## Scan and Go Updates
-- Display message while processing checkout to let user know they can scan the next item. (*KP*)
+- Display message while processing checkout to let user know they can scan the next item. (DIS-773) (*KP*)

--- a/release-notes/25.06.00.MD
+++ b/release-notes/25.06.00.MD
@@ -6,3 +6,7 @@
 //imani
 
 //ian
+
+//katherine
+## Scan and Go Updates
+- Display message while processing checkout to let user know they can scan the next item. (*KP*)


### PR DESCRIPTION
- Add message above loading spinner on Scan and Go page to let the user know they can go ahead and scan the next item.
- Update release notes.