### PR TITLE
DIS-780: QA fix for typing in barcodes for selfcheck

### DIFF
--- a/code/src/screens/SCO/SelfCheckOut.js
+++ b/code/src/screens/SCO/SelfCheckOut.js
@@ -22,7 +22,8 @@ export const SelfCheckOut = () => {
      const { language } = React.useContext(LanguageContext);
      const { user, cards, updateUser } = React.useContext(UserContext);
      const { checkouts, updateCheckouts } = React.useContext(CheckoutsContext);
-     const [items, setItems] = React.useState([]);
+     const passedItems = useRoute().params?.items ?? [];
+     const [items, setItems] = React.useState(passedItems);
      const { selfCheckSettings } = React.useContext(LibraryBranchContext);
 
      let startNew = useRoute().params?.startNew ?? false;
@@ -233,6 +234,7 @@ export const SelfCheckOut = () => {
                                                            type: null,
                                                            activeAccount,
                                                            startNew: false,
+                                                           items,
                                                       });
                                                  }}>
                                                       {getTermFromDictionary(language, 'add_new_item')}


### PR DESCRIPTION
When typing in a barcode for LiDA self-check, already checked out items weren't getting passed when the screen reloads during checkout, so only the most recent checkout showed up in the list.  Now the items are passed during navigation.