### PR TITLE
DIS-1038: LiDA notification permissions

### DIFF
--- a/code/src/screens/MyAccount/Settings/Permission/Notifications.js
+++ b/code/src/screens/MyAccount/Settings/Permission/Notifications.js
@@ -461,7 +461,7 @@ const NotificationToggle = (data) => {
                     setNotifyAccount(value);
                }
                await getAppPreferencesForUser(library.baseUrl, language).then((result) => {
-                    updateAppPreferences(data);
+                    updateAppPreferences(result);
                });
 
                queryClient.invalidateQueries({ queryKey: ['user', library.baseUrl, language] });
@@ -510,7 +510,7 @@ const NotificationToggleAll = (data) => {
                setNotifyCustom(allowAllNotifications);
                setNotifyAccount(allowAllNotifications);
                await getAppPreferencesForUser(library.baseUrl, language).then((result) => {
-                    updateAppPreferences(data);
+                    updateAppPreferences(result);
                });
 
                queryClient.invalidateQueries({ queryKey: ['user', library.baseUrl, language] });

--- a/code/src/screens/MyAccount/Settings/Permission/Notifications.js
+++ b/code/src/screens/MyAccount/Settings/Permission/Notifications.js
@@ -444,7 +444,7 @@ const NotificationToggle = (data) => {
 
      const updatePreference = async (pref, value) => {
           let allowNotification = true;
-          if (value === 0 || value === 'false' || value === false) {
+          if (value === 0 || value === 'false' || value === false || value === '0') {
                allowNotification = true;
           } else {
                allowNotification = false;

--- a/release-notes/25.07.00.MD
+++ b/release-notes/25.07.00.MD
@@ -12,6 +12,9 @@
 // katherine - grove
 
 // imani
+### Aspen LiDA Updates
+- Modified NotificationToggle to pass results into getAppPreferences into updateAppPreferences call which had been preventing more then 1 change to notification preferences happening from notification permission screen.
+- added '0' to value check in updatePreference in NotificationToggle which in some cases was causing notification permissions to not be turned on properly.
 
 //alexander - open fifth
 - Convert data to string in updateSelectedLibrary. (DIS-955) (*AB*)


### PR DESCRIPTION
to test:
* Open up Lida and navigate to the device permissions for Notifications (more > preferences > Device permissions > Notifications)
* set any of the 3 toggles on
* check in the database of the connected aspen for a line in the user_notification_tokens matching the userId of the account you are logged into LiDA with. the columns notifySavedSearch, notifyCustom, and notifyAccount should have values matching the three sliders in your notifications screen in your LiDA app. (it may have a slight delay if they don't match wait a second and re-check)
* if you continue making changes to the slider they should be reflected in the database.
* both turn the permissions on and turning them off work from LiDA