### PR TITLE
DIS-276 Prevent valid users from being force logged out

### DIFF
--- a/code/src/navigations/drawer/DrawerContent.js
+++ b/code/src/navigations/drawer/DrawerContent.js
@@ -27,7 +27,7 @@ import { fetchSavedEvents } from '../../util/api/event';
 import { getCatalogStatus } from '../../util/api/library';
 import { getLists } from '../../util/api/list';
 import { getLocations } from '../../util/api/location';
-import { fetchNotificationHistory, fetchReadingHistory, fetchSavedSearches, getLinkedAccounts, getPatronCheckedOutItems, sortCheckouts, getPatronHolds, sortHolds, getViewerAccounts, reloadProfile, revalidateUser, validateSession } from '../../util/api/user';
+import { fetchNotificationHistory, fetchReadingHistory, fetchSavedSearches, getLinkedAccounts, getPatronCheckedOutItems, sortCheckouts, getPatronHolds, sortHolds, getViewerAccounts, refreshProfile, reloadProfile, revalidateUser, validateSession } from '../../util/api/user';
 import { passUserToDiscovery } from '../../util/apiAuth';
 import { GLOBALS } from '../../util/globals';
 import { formatDiscoveryVersion, getPickupLocations, reloadBrowseCategories } from '../../util/loadLibrary';
@@ -107,14 +107,16 @@ export const DrawerContent = () => {
           },
      });
 
-     useQuery(['user', library.baseUrl, language], () => reloadProfile(library.baseUrl), {
+     //MDN 25.08 DIS-276 Change to use refresh profile rather than reload profile because it utilizes caching within
+     //Aspen Discovery to return results as quickly as possible.
+     useQuery(['user', library.baseUrl, language], () => refreshProfile(library.baseUrl), {
           initialData: user,
           refetchInterval: 60 * 1000 * 5,
           refetchIntervalInBackground: true,
           refetchOnWindowFocus: 'always',
           onSuccess: (data) => {
                const validProfile = data.success ?? true;
-               if(validProfile) {
+               if (validProfile) {
                     setInvalidSession(false);
                     if (user) {
                          if (data !== user) {
@@ -128,10 +130,14 @@ export const DrawerContent = () => {
                          PATRON.language = data.interfaceLanguage ?? 'en';
                     }
                } else {
-                    // no profile returned, invalid user
-                    logWarnMessage("Session was invalid reloading profile");
-                    logWarnMessage(data);
-                    setInvalidSession(true);
+                    //MDN 25.08 DIS-276 Change to use refresh profile rather than reload profile because it utilizes caching within
+                    errorFetching = data.errorFetching ?? false;
+                    //If we had an error fetching data, do not force the user out
+                    if (errorFetching === false) {
+                         logWarnMessage("Session was invalid after reloading profile");
+                         logWarnMessage(data);
+                         setInvalidSession(true);
+                    }
                }
           },
      });
@@ -372,6 +378,7 @@ export const DrawerContent = () => {
      }
 
      if (invalidSession === true || invalidSession === 'true') {
+          logDebugMessage("Session is invalid, preparing to show invalid credentials alert");
           return <InvalidCredentials />;
      }
 

--- a/code/src/screens/Auth/InvalidCredentials.js
+++ b/code/src/screens/Auth/InvalidCredentials.js
@@ -6,6 +6,8 @@ import {AuthContext} from '../../components/navigation';
 import {LanguageContext, ThemeContext} from '../../context/initialContext';
 import {getTermFromDictionary} from '../../translations/TranslationService';
 
+import { logDebugMessage, logInfoMessage, logWarnMessage, logErrorMessage } from '../../util/logging.js';
+
 export const InvalidCredentials = () => {
      const { theme, colorMode, textColor } = React.useContext(ThemeContext);
      const { language } = React.useContext(LanguageContext);
@@ -13,6 +15,7 @@ export const InvalidCredentials = () => {
      const [isOpen, setIsOpen] = React.useState(true);
      const onClose = () => setIsOpen(false);
      const cancelRef = React.useRef(null);
+     logDebugMessage('Showing Invalid Credentials Alert');
 
      return (
           <Center>

--- a/code/src/util/api/user.js
+++ b/code/src/util/api/user.js
@@ -21,7 +21,7 @@ export async function refreshProfile(url) {
      const postBody = await postData();
      const discovery = create({
           baseURL: url,
-          timeout: GLOBALS.timeoutAverage,
+          timeout: GLOBALS.timeoutSlow,
           headers: getHeaders(endpoint.isPost),
           auth: createAuthTokens(),
           params: {
@@ -29,8 +29,8 @@ export async function refreshProfile(url) {
                checkIfValid: false,
           },
      });
+     logDebugMessage("Refreshing profile");
      const response = await discovery.post(`${endpoint.url}getPatronProfile`, postBody);
-     console.log(response);
      if (response.ok) {
           if (response.data?.result) {
                //console.log(response.data.result.profile);
@@ -39,10 +39,15 @@ export async function refreshProfile(url) {
                } else {
                     return response.data.result;
                }
+          }else{
+               logWarnMessage("Refreshing profile failed, did not get a result");
           }
+     }else{
+          logWarnMessage("Refreshing profile failed did not get an ok response");
      }
      return {
           success: false,
+          errorFetching: true
      };
 }
 
@@ -54,7 +59,7 @@ export async function reloadProfile(url) {
      const postBody = await postData();
      const discovery = create({
           baseURL: url,
-          timeout: GLOBALS.timeoutAverage,
+          timeout: GLOBALS.timeoutSlow, //MDN 25.08 DIS-276 use the slow timeout to give connections to eContent time to reload
           headers: getHeaders(endpoint.isPost),
           auth: createAuthTokens(),
           params: {
@@ -63,6 +68,7 @@ export async function reloadProfile(url) {
                checkIfValid: false,
           },
      });
+     logDebugMessage("Reloading profile");
      const response = await discovery.post(`${endpoint.url}getPatronProfile`, postBody);
      if (response.ok) {
           if (response.data.result) {
@@ -72,10 +78,15 @@ export async function reloadProfile(url) {
                } else {
                     return response.data.result;
                }
+          }else{
+               logWarnMessage("Reloading profile failed, did not get a result");
           }
+     }else{
+          logWarnMessage("Reloading profile failed");
      }
      return {
           success: false,
+          errorFetching: true
      };
 }
 
@@ -123,8 +134,11 @@ export async function validateUser(username, password, url) {
           auth: createAuthTokens(),
      });
      const results = await discovery.post('/UserAPI?method=validateAccount', postBody);
+     logDebugMessage("Validating User");
      if (results.ok) {
           return results.data.result;
+     }else{
+          logWarnMessage("Validating User failed");
      }
 }
 
@@ -141,12 +155,13 @@ export async function validateSession(url) {
           auth: createAuthTokens(),
      });
      const response = await api.post('/UserAPI?method=validateSession', postBody);
+     logDebugMessage("Validating Session");
      if (response.ok) {
           if (response?.data?.result) {
                return response.data.result;
           }
      } else {
-          console.log(response);
+          logWarnMessage("Validating Session failed");
      }
      return [];
 }
@@ -164,14 +179,15 @@ export async function revalidateUser(url) {
           auth: createAuthTokens(),
      });
      const response = await api.post('/UserAPI?method=validateUserCredentials', postBody);
+     logDebugMessage("Revalidating User");
      if (response.ok) {
           if (response?.data?.result?.valid) {
                return response.data.result.valid;
           } else {
-               console.log(response.data);
+               logWarnMessage("Revalidating user return invalid");
           }
      } else {
-          console.log(response);
+          logWarnMessage("Revalidating user failed");
      }
      return false;
 }


### PR DESCRIPTION
Three part fix:
1) Increase the timeout to the slow timeout
2) If the call to discovery fails (i.e. times out) for reloadProfile or refreshProfile, indicate that in the response and don't force the user out 3) Change to use refreshProfile rather than reloadProfile so we take better advantage of caching within Discovery