### PR TITLE
DIS-1371 barcode reader not working

### DIFF
--- a/code/src/screens/Auth/LoginForm.js
+++ b/code/src/screens/Auth/LoginForm.js
@@ -73,7 +73,11 @@ export const GetLoginForm = (props) => {
                try {
 
                     const defaultUsername = await SecureStore.getItemAsync('defaultUsername');
-                    if (defaultUsername !== null) {
+                    if (barcode) 
+					{
+						setUsername(barcode);
+					}
+					else if (defaultUsername !== null && defaultUsername) {
                          setUsername(defaultUsername); // Set the retrieved username
                          //logDebugMessage("Default username is: " + defaultUsername);
                     }
@@ -85,7 +89,7 @@ export const GetLoginForm = (props) => {
           };
 
           loadDefaultUsername();
-     }, []);
+     }, [barcode]);
 
      const initialValidation = async () => {
           setLoginError(false);

--- a/code/src/screens/Auth/LoginForm.js
+++ b/code/src/screens/Auth/LoginForm.js
@@ -71,13 +71,12 @@ export const GetLoginForm = (props) => {
      React.useEffect(() => {
           const loadDefaultUsername = async () => {
                try {
-
                     const defaultUsername = await SecureStore.getItemAsync('defaultUsername');
                     if (barcode) 
-					{
-						setUsername(barcode);
-					}
-					else if (defaultUsername !== null && defaultUsername) {
+                    {
+                         setUsername(barcode);
+                    }
+                    else if (defaultUsername !== null && defaultUsername) {
                          setUsername(defaultUsername); // Set the retrieved username
                          //logDebugMessage("Default username is: " + defaultUsername);
                     }

--- a/release-notes/25.10.00.MD
+++ b/release-notes/25.10.00.MD
@@ -8,5 +8,6 @@
 //leo
 
 //imani
+- update LoginForm to add back ability to load a username from a scanned barcode. 
 
 //alexander

--- a/release-notes/25.10.00.MD
+++ b/release-notes/25.10.00.MD
@@ -8,6 +8,6 @@
 //leo
 
 //imani
-- update LoginForm to add back ability to load a username from a scanned barcode. 
+- update LoginForm to add back ability to load a username from a scanned barcode. (DIS-1371) (*IT*)
 
 //alexander


### PR DESCRIPTION
Test Plan
* open LiDA
* pick a library
* at the login screen press the barcode icon to open the barcode scanner
* scan a barcode
* the value of the barcode you scanned should now be displayed in the library Card Number field

Prior to this update the login form would be returned to but no update would have occured. 
Ensure DIS-1130 (https://aspen-discovery.atlassian.net/browse/DIS-1130) still functions properly (last input username should be remembered if user log outs or is forced out due to a network disconnect)  This should only get over-written if a barcode is scanned. 
