### PR TITLE
DIS-1633: Disable "Renew All" Button Per Request

### DIFF
--- a/code/src/screens/MyAccount/CheckedOutTitles/MyCheckouts.js
+++ b/code/src/screens/MyAccount/CheckedOutTitles/MyCheckouts.js
@@ -351,9 +351,11 @@ export const MyCheckouts = () => {
                               <Button
                                    isLoading={renewAll}
                                    isLoadingText={getTermFromDictionary(language, 'renewing_all', true)}
+                                   isDisabled={renewAll}
                                    size="sm"
                                    bgColor={theme['colors']['primary']['500']}
                                    onPress={() => {
+                                        if (renewAll) return;
                                         setRenewAll(true);
                                         renewAllCheckouts(library.baseUrl, language).then((result) => {
                                              if (result?.confirmRenewalFee && result.confirmRenewalFee) {

--- a/code/src/screens/MyAccount/CheckedOutTitles/MyCheckouts.js
+++ b/code/src/screens/MyAccount/CheckedOutTitles/MyCheckouts.js
@@ -378,8 +378,10 @@ export const MyCheckouts = () => {
                                              setRenewAll(false);
                                         });
                                    }}>
-                                   <ButtonIcon color={theme['colors']['primary']['500-text']}  as={MaterialIcons} name="autorenew" />
-                                   <ButtonText color={theme['colors']['primary']['500-text']}>{getTermFromDictionary(language, 'checkout_renew_all')}</ButtonText>
+                                   {!renewAll && <ButtonIcon color={theme['colors']['primary']['500-text']} as={MaterialIcons} name="autorenew" />}
+                                   <ButtonText color={theme['colors']['primary']['500-text']}>
+                                        {renewAll ? getTermFromDictionary(language, 'renewing_all', true) : getTermFromDictionary(language, 'checkout_renew_all')}
+                                   </ButtonText>
                               </Button>
                               <Button
                                    borderColor={theme['colors']['primary']['500']}

--- a/code/src/translations/defaults.json
+++ b/code/src/translations/defaults.json
@@ -133,7 +133,7 @@
   "no_checkouts": "You have no items checked out",
   "checkout_renew": "Renew",
   "checkout_renew_all": "Renew All",
-  "renewing_all": "Renewing all",
+  "renewing_all": "Renewing All",
   "renewing": "Renewing",
   "if_eligible_auto_renew": "If eligible, this item will renew on",
   "not_eligible_for_renewals": "This item is not eligible for renewal",

--- a/release-notes/25.12.00.MD
+++ b/release-notes/25.12.00.MD
@@ -4,5 +4,7 @@
 // kirstien
 
 // leo
+### Other Updates
+- Disabled the "Renew All" button after a request to prevent multiple rapid renewal requests from button spamming. (DIS-1633) (*LS*)
 
 // imani


### PR DESCRIPTION
- Disabled the "Renew All" button after a request to prevent multiple rapid renewal requests from button spamming.

Test Plan:
1. Open your LiDA application of choice.
2. Navigate to the Checkouts screen with renewable items.
3. Click “Renew” all multiple times. Notice the number of renewals remaining has dropped more than 1 for each item.
4. Apply the patch.
5. Repeat step 3. Notice that the button cannot be clicked more than once per request.

