### PR TITLE
DIS-1680: Add hoopla holds tab

### DIFF
--- a/code/src/screens/MyAccount/TitlesOnHold/MyHolds.js
+++ b/code/src/screens/MyAccount/TitlesOnHold/MyHolds.js
@@ -119,6 +119,8 @@ export const MyHolds = () => {
                     navigation.setOptions({ title: getTermFromDictionary(language, 'titles_on_hold_for_ils') });
                } else if (value === 'overdrive') {
                     navigation.setOptions({ title: filterByLibbyTitle });
+               } else if (value === 'hoopla') {
+                    navigation.setOptions({ title: getTermFromDictionary(language, 'titles_on_hold_for_hoopla') });
                } else if (value === 'cloud_library') {
                     navigation.setOptions({ title: getTermFromDictionary(language, 'titles_on_hold_for_cloud_library') });
                } else if (value === 'axis360') {
@@ -516,6 +518,8 @@ export const MyHolds = () => {
                          return getTermFromDictionary(language, 'filter_by_ils') + " (" + (user.numHoldsRequestedIls ?? 0) + ")";
                     case "overdrive":
                          return filterByLibby + " (" + (user.numHoldsOverDrive ?? 0) + ")";
+                    case "hoopla":
+                         return getTermFromDictionary(language, 'filter_by_hoopla') + " (" + (user.numHolds_Hoopla ?? 0) + ")";
                     case "cloud_library":
                          return getTermFromDictionary(language, 'filter_by_cloud_library') + " (" + (user.numHolds_cloudLibrary ?? 0) + ")";
                     case "axis360":
@@ -572,9 +576,10 @@ export const MyHolds = () => {
                                                   <SelectItem label={getTermFromDictionary(language, 'filter_by_all') + ' (' + (user.numHolds ?? 0) + ')'} value="all" key={0}  bgColor={holdSource == "all" ? theme['colors']['tertiary']['300'] : ''} sx={{ _text: { color: holdSource == "all" ? theme['colors']['tertiary']['500-text'] : textColor } }}/>
                                                   <SelectItem label={getTermFromDictionary(language, 'filter_by_ils') + ' (' + (user.numHoldsRequestedIls ?? 0) + ')'} value="ils" key={1}  bgColor={holdSource == "ils" ? theme['colors']['tertiary']['300'] : ''} sx={{ _text: { color: holdSource == "ils" ? theme['colors']['tertiary']['500-text'] : textColor } }}/>
                                                   {user.isValidForOverdrive ? <SelectItem label={filterByLibby + ' (' + (user.numHoldsOverDrive ?? 0) + ')'} value="overdrive" key={2}  bgColor={holdSource == "overdrive" ? theme['colors']['tertiary']['300'] : ''} sx={{ _text: { color: holdSource == "overdrive" ? theme['colors']['tertiary']['500-text'] : textColor } }} /> : null}
-                                                  {user.isValidForCloudLibrary ? <SelectItem label={getTermFromDictionary(language, 'filter_by_cloud_library') + ' (' + (user.numHolds_cloudLibrary ?? 0) + ')'} value="cloud_library" key={3}  bgColor={holdSource == "cloud_library" ? theme['colors']['tertiary']['300'] : ''} sx={{ _text: { color: holdSource == "cloud_library" ? theme['colors']['tertiary']['500-text'] : textColor } }}/> : null}
-                                                  {user.isValidForAxis360 ? <SelectItem label={getTermFromDictionary(language, 'filter_by_boundless') + ' (' + (user.numHolds_axis360 ?? 0) + ')'} value="axis360" key={4}  bgColor={holdSource == "axis360" ? theme['colors']['tertiary']['300'] : ''} sx={{ _text: { color: holdSource == "axis360" ? theme['colors']['tertiary']['500-text'] : textColor } }}/> : null}
-                                                  {user.isValidForPalaceProject ? <SelectItem label={getTermFromDictionary(language, 'filter_by_palace_project') + ' (' + (user.numHolds_PalaceProject ?? 0) + ')'} value="palace_project" key={5}  bgColor={holdSource == "palace_project" ? theme['colors']['tertiary']['300'] : ''} sx={{ _text: { color: holdSource == "palace_project" ? theme['colors']['tertiary']['500-text'] : textColor } }}/> : null}
+                                                  {user.isValidForHoopla ? <SelectItem label={getTermFromDictionary(language, 'filter_by_hoopla') + ' (' + (user.numHolds_Hoopla ?? 0) + ')'} value="hoopla" key={3}  bgColor={holdSource == "hoopla" ? theme['colors']['tertiary']['300'] : ''} sx={{ _text: { color: holdSource == "hoopla" ? theme['colors']['tertiary']['500-text'] : textColor } }}/> : null}
+                                                  {user.isValidForCloudLibrary ? <SelectItem label={getTermFromDictionary(language, 'filter_by_cloud_library') + ' (' + (user.numHolds_cloudLibrary ?? 0) + ')'} value="cloud_library" key={4}  bgColor={holdSource == "cloud_library" ? theme['colors']['tertiary']['300'] : ''} sx={{ _text: { color: holdSource == "cloud_library" ? theme['colors']['tertiary']['500-text'] : textColor } }}/> : null}
+                                                  {user.isValidForAxis360 ? <SelectItem label={getTermFromDictionary(language, 'filter_by_boundless') + ' (' + (user.numHolds_axis360 ?? 0) + ')'} value="axis360" key={5}  bgColor={holdSource == "axis360" ? theme['colors']['tertiary']['300'] : ''} sx={{ _text: { color: holdSource == "axis360" ? theme['colors']['tertiary']['500-text'] : textColor } }}/> : null}
+                                                  {user.isValidForPalaceProject ? <SelectItem label={getTermFromDictionary(language, 'filter_by_palace_project') + ' (' + (user.numHolds_PalaceProject ?? 0) + ')'} value="palace_project" key={6}  bgColor={holdSource == "palace_project" ? theme['colors']['tertiary']['300'] : ''} sx={{ _text: { color: holdSource == "palace_project" ? theme['colors']['tertiary']['500-text'] : textColor } }}/> : null}
                                              </SelectContent>
                                         </SelectPortal>
                                    </Select>
@@ -683,4 +688,3 @@ export const MyHolds = () => {
           </Box>
      );
 };
-

--- a/code/src/translations/TranslationService.js
+++ b/code/src/translations/TranslationService.js
@@ -278,6 +278,10 @@ export async function getTranslatedTermsForAllLanguages(languages, url) {
                     value: getTermFromDictionary(language, 'libby'),
                },
                {
+                    key: 'titles_on_hold_for_hoopla',
+                    value: getTermFromDictionary(language, 'hoopla'),
+               },
+               {
                     key: 'titles_on_hold_for_cloud_library',
                     value: getTermFromDictionary(language, 'cloud_library'),
                },

--- a/release-notes/25.12.00.MD
+++ b/release-notes/25.12.00.MD
@@ -3,6 +3,10 @@
 
 // kirstien
 
+// yanjun
+### Hoopla Updates
+- Add Hoopla Holds in My Account > Tittles on Holds so patrons can view and manage Hoopla holds on LiDA. (DIS-1680) (*YL*)
+
 // leo
 ### User Lists Updates
 - If "Hide Soft Delete UI for Lists" is enabled under Library System settings, soft-deletion text and opt-out checkbox will not display when deleting a list. (DIS-1584) (*LS*)


### PR DESCRIPTION
Aspen Discovery now supports Hoopla holds for libraries that enable Hoopla Flex, so LiDA should follow suit. Add Hoopla as a source on My Account > Titles on Hold so patrons can view and manage their Hoopla holds within the app.

To test:
1. Log in as a patron whose home library supports hoopla flex
2. Place a hold on Hoopla records on Aspen Discovery or LiDA
3. View Hoopla holds on My Account > Titles on Hold
4. Cancel hoopla holds 
5. Log out and log in as another patron whose home library doesn't support hoopla flex
6. Go to My Account > Titles on Hold and don't find Hoopla in the dropdown. 