### PR TITLE
Dis 1697 enable self registration in app

### DIFF
--- a/code/src/screens/Auth/Login.js
+++ b/code/src/screens/Auth/Login.js
@@ -166,7 +166,7 @@ export const LoginScreen = () => {
                     }
 
                     if (result.catalogRegistrationCapabilities) {
-                              if(String(result.catalogRegistrationCapabilities.enableSelfRegistration) === '1' && String(result.catalogRegistrationCapabilities.enableSelfRegistrationInApp === '1')) {
+                              if(String(result.catalogRegistrationCapabilities.enableSelfRegistration) === '1' && String(result.catalogRegistrationCapabilities.enableSelfRegistrationInApp) === '1') {
                                    setEnableSelfRegistration(1);
                               } else {
                                    setEnableSelfRegistration(0);

--- a/release-notes/26.01.00.MD
+++ b/release-notes/26.01.00.MD
@@ -6,5 +6,7 @@
 //leo
 
 //imani
+### Other Updates
+- Fixing enableSelfRegistrationInApp value in login being ignored and always evaluating as if it were set enabled(DIS-1697) (*IT*) 
 
 //alexander


### PR DESCRIPTION
* Enable self registration for your discovery site
* in the LiDA General settings, disable self registration from the App
* Open the app navigate to a library your settings apply to and there should be no self register link.
* Before these changes the link would appear.

https://aspen-discovery.atlassian.net/browse/DIS-1697