### PR TITLE
DIS-1858 flexible reset text size

### DIFF
--- a/code/src/screens/Auth/ResetPassword.js
+++ b/code/src/screens/Auth/ResetPassword.js
@@ -134,7 +134,7 @@ export const ResetPassword = (props) => {
      return (
           <Center>
                <Button variant="link" onPress={() => setShowForgotPasswordModal(true)}>
-                    <ButtonText color={theme['colors']['primary']['500']}>{buttonLabel}</ButtonText>
+                    <ButtonText style={ buttonLabel.length > 80 ? {fontSize: 12} : undefined} color={theme['colors']['primary']['500']}>{buttonLabel}</ButtonText>
                </Button>
                <Modal isOpen={showForgotPasswordModal} size="lg" avoidKeyboard={true} onClose={() => setShowForgotPasswordModal(false)}>
                     <ModalBackdrop />

--- a/release-notes/26.02.00.MD
+++ b/release-notes/26.02.00.MD
@@ -4,3 +4,4 @@
 // kirstien
 
 // imani
+- Added conditional formatting to ButtonText in ResetPassword to avoid cutting off text when long translations placed there ([DIS-1858](https://aspen-discovery.atlassian.net/browse/DIS-1858)) (*IT*)


### PR DESCRIPTION
https://aspen-discovery.atlassian.net/browse/DIS-1858

To Test:
* use translations to replace the Forgot PIN? message with text that is more then 80 characters in length
* open up the login form for the appropriate library system in LiDA and the text should be smaller to accommodate the longer text.
* text that is shorter should remain unaffected.