### PR TITLE
DIS-1902 Fix parsing of library info in Update Selected Library

### DIFF
--- a/code/src/screens/Auth/Login.js
+++ b/code/src/screens/Auth/Login.js
@@ -129,10 +129,10 @@ export const LoginScreen = () => {
           LIBRARY.url = data.baseUrl; // used in some cases before library context is set
           await getLibraryInfo(data.baseUrl, data.libraryId).then(async (result) => {
                if (_.isObject(result)) {
-                    const library = data.data.result?.library ?? [];
+                    const library = result.data.result?.library ?? [];
                     logDebugMessage("Updating library from Login screen");
                     updateLibrary(library);
-                    if (result.barcodeStyle) {
+                    if (library.barcodeStyle) {
                          setAllowBarcodeScanner(true);
                          if (result.barcodeStyle === 'CODE39') {
                               setAllowCode39(true);
@@ -141,32 +141,32 @@ export const LoginScreen = () => {
                          setAllowBarcodeScanner(false);
                     }
 
-                    if (result.usernameLabel) {
-                         setUsernameLabel(result.usernameLabel);
+                    if (library.usernameLabel) {
+                         setUsernameLabel(library.usernameLabel);
                     }
 
-                    if (result.passwordLabel) {
-                         setPasswordLabel(result.passwordLabel);
+                    if (library.passwordLabel) {
+                         setPasswordLabel(library.passwordLabel);
                     }
 
-                    if (result.enableForgotPasswordLink) {
-                         setEnableForgotPasswordLink(result.enableForgotPasswordLink);
+                    if (library.enableForgotPasswordLink) {
+                         setEnableForgotPasswordLink(library.enableForgotPasswordLink);
                     }
 
-                    if (result.enableForgotBarcode) {
-                         setEnableForgotBarcode(result.enableForgotBarcode);
+                    if (library.enableForgotBarcode) {
+                         setEnableForgotBarcode(library.enableForgotBarcode);
                     }
 
-                    if (result.forgotPasswordType) {
-                         setForgotPasswordType(result.forgotPasswordType);
+                    if (library.forgotPasswordType) {
+                         setForgotPasswordType(library.forgotPasswordType);
                     }
 
-                    if (result.ils) {
-                         setIls(result.ils);
+                    if (library.ils) {
+                         setIls(library.ils);
                     }
 
-                    if (result.catalogRegistrationCapabilities) {
-                              if(String(result.catalogRegistrationCapabilities.enableSelfRegistration) === '1' && String(result.catalogRegistrationCapabilities.enableSelfRegistrationInApp) === '1') {
+                    if (library.catalogRegistrationCapabilities) {
+                              if(String(library.catalogRegistrationCapabilities.enableSelfRegistration) === '1' && String(library.catalogRegistrationCapabilities.enableSelfRegistrationInApp) === '1') {
                                    setEnableSelfRegistration(1);
                               } else {
                                    setEnableSelfRegistration(0);

--- a/release-notes/26.02.00.MD
+++ b/release-notes/26.02.00.MD
@@ -4,3 +4,4 @@
 // kirstien
 
 // imani
+- Correct setting info from getLibraryInfo in updatedSelectedLibrary ([DIS-1902](https://aspen-discovery.atlassian.net/browse/DIS-1902)) (*IT*)


### PR DESCRIPTION
to test:
* if you have a translation for the Password Label in LiDA you should see it on the login screen of LiDA now.
* if you did not havce a translation add a translation for Password/PIN at [/API/SystemAPI?method=getBulkTranslations&language=en](https://catalog.deerfieldlibrary.org/API/SystemAPI?method=getBulkTranslations&language=en)

https://aspen-discovery.atlassian.net/browse/DIS-1902