### PR TITLE
DIS-1946: Invalidate holds cache after Manage All requests

### DIFF
--- a/code/src/screens/MyAccount/TitlesOnHold/MyHold.js
+++ b/code/src/screens/MyAccount/TitlesOnHold/MyHold.js
@@ -19,6 +19,7 @@ import { SelectThawDate } from './SelectThawDate.js';
 import { PATRON } from '../../../util/loadPatron';
 
 import { logDebugMessage, logInfoMessage, logWarnMessage, logErrorMessage } from '../../../util/logging.js';
+import { useQueryClient } from '@tanstack/react-query';
 
 const blurhash = 'MHPZ}tt7*0WC5S-;ayWBofj[K5RjM{ofM_';
 
@@ -562,11 +563,13 @@ export const ManageSelectedHolds = (props) => {
 };
 
 export const ManageAllHolds = (props) => {
+     const queryClient = useQueryClient();
      const { resetGroup } = props;
      const { language } = React.useContext(LanguageContext);
      const { holds, updateHolds } = React.useContext(HoldsContext);
      const { library } = React.useContext(LibrarySystemContext);
      const { theme, colorMode, textColor } = React.useContext(ThemeContext);
+     const { user } = React.useContext(UserContext);
      const insets = useSafeAreaInsets();
 
      const [showActionsheet, setShowActionsheet] = React.useState(false)
@@ -645,6 +648,7 @@ export const ManageAllHolds = (props) => {
                                         onClose(onClose);
                                         startFreezing(false);
                                    });
+                                   queryClient.invalidateQueries({ queryKey: ['holds', user.id, library.baseUrl, language] });
                               }}>
                               <ActionsheetItemText color={textColor}>{numToFreezeLabel}</ActionsheetItemText>
                          </ActionsheetItem>
@@ -681,6 +685,7 @@ export const ManageAllHolds = (props) => {
                                              handleClose();
                                              startCancelling(false);
                                         });
+                                        queryClient.invalidateQueries({ queryKey: ['holds', user.id, library.baseUrl, language] });
                                    }}>
                                    <ActionsheetItemText color={textColor}>{numToCancelLabel}</ActionsheetItemText>
                               </ActionsheetItem>
@@ -697,6 +702,7 @@ export const ManageAllHolds = (props) => {
                                              handleClose();
                                              startThawing(false);
                                         });
+                                        queryClient.invalidateQueries({ queryKey: ['holds', user.id, library.baseUrl, language] });
                                    }}>
                                    <ActionsheetItemText color={textColor}>{numToThawLabel}</ActionsheetItemText>
                               </ActionsheetItem>

--- a/release-notes/26.02.00.MD
+++ b/release-notes/26.02.00.MD
@@ -13,3 +13,4 @@
 - Added conditional formatting to ButtonText in ResetPassword to avoid cutting off text when long translations placed there ([DIS-1858](https://aspen-discovery.atlassian.net/browse/DIS-1858)) (*IT*)
 - Clean up selected library information updating ([DIS-1838](https://aspen-discovery.atlassian.net/browse/DIS-1838)) (*IT*)
 - Add ability to link to selfRegistrationURL for library systems( [DIS-1838](https://aspen-discovery.atlassian.net/browse/DIS-1838)) (*IT*)
+- On the Holds screen, after using the Manage All button to freeze/thaw/cancel, invalidate the holds cache to display the correct status of all holds. ([DIS-1946](https://aspen-discovery.atlassian.net/browse/DIS-1946)) (*KK*)


### PR DESCRIPTION
Holds data was updating too quickly when using Manage All functionality which resulted in the status of all the holds not being correct (as they continued to update in the background). Added an invalidateQueries call to get updated data after all requests.