### PR TITLE
DIS-1652 allow indefinite hold freezes

### DIFF
--- a/code/src/screens/MyAccount/TitlesOnHold/MyHold.js
+++ b/code/src/screens/MyAccount/TitlesOnHold/MyHold.js
@@ -321,7 +321,7 @@ export const MyHold = (props) => {
                                    isLoadingText={getTermFromDictionary(language, 'freezing_hold', true)}
                                    onPress={() => {
                                         startFreezing(true);
-                                        freezeHold(hold.cancelId, record, hold.source, library.baseUrl, hold.userId, language).then((r) => {
+                                        freezeHold(hold.cancelId, record, hold.source, library.baseUrl, hold.userId, language, library.allowIndefiniteHoldFreezes ?? false).then((r) => {
                                              resetGroup();
                                              handleClose();
                                              startFreezing(false);
@@ -522,7 +522,7 @@ export const ManageSelectedHolds = (props) => {
                               isLoadingText={getTermFromDictionary(language, 'freezing_hold', true)}
                               onPress={() => {
                                    startFreezing(true);
-                                   freezeHolds(titlesToFreeze, library.baseUrl).then((r) => {
+                                   freezeHolds(titlesToFreeze, library.baseUrl, allowIndefinite = library.allowIndefiniteHoldFreezes ?? false).then((r) => {
                                         resetGroup();
                                         handleClose();
                                         startFreezing(false);
@@ -640,7 +640,7 @@ export const ManageAllHolds = (props) => {
                               isLoadingText={getTermFromDictionary(language, 'freezing_hold', true)}
                               onPress={() => {
                                    startFreezing(true);
-                                   freezeHolds(titlesToFreeze, library.baseUrl).then((r) => {
+                                   freezeHolds(titlesToFreeze, library.baseUrl, allowIndefinite = library.allowIndefiniteHoldFreezes ?? false).then((r) => {
                                         resetGroup();
                                         onClose(onClose);
                                         startFreezing(false);

--- a/code/src/screens/MyAccount/TitlesOnHold/MyHold.js
+++ b/code/src/screens/MyAccount/TitlesOnHold/MyHold.js
@@ -321,7 +321,7 @@ export const MyHold = (props) => {
                                    isLoadingText={getTermFromDictionary(language, 'freezing_hold', true)}
                                    onPress={() => {
                                         startFreezing(true);
-                                        freezeHold(hold.cancelId, record, hold.source, library.baseUrl, hold.userId, language, library.allowIndefiniteHoldFreezes ?? false).then((r) => {
+                                        freezeHold(hold.cancelId, record, hold.source, library.baseUrl, hold.userId, language, library.reactivateDateNotRequired ?? false).then((r) => {
                                              resetGroup();
                                              handleClose();
                                              startFreezing(false);
@@ -522,7 +522,7 @@ export const ManageSelectedHolds = (props) => {
                               isLoadingText={getTermFromDictionary(language, 'freezing_hold', true)}
                               onPress={() => {
                                    startFreezing(true);
-                                   freezeHolds(titlesToFreeze, library.baseUrl, allowIndefinite = library.allowIndefiniteHoldFreezes ?? false).then((r) => {
+                                   freezeHolds(titlesToFreeze, library.baseUrl, allowIndefinite = library.reactivateDateNotRequired ?? false).then((r) => {
                                         resetGroup();
                                         handleClose();
                                         startFreezing(false);
@@ -640,7 +640,7 @@ export const ManageAllHolds = (props) => {
                               isLoadingText={getTermFromDictionary(language, 'freezing_hold', true)}
                               onPress={() => {
                                    startFreezing(true);
-                                   freezeHolds(titlesToFreeze, library.baseUrl, allowIndefinite = library.allowIndefiniteHoldFreezes ?? false).then((r) => {
+                                   freezeHolds(titlesToFreeze, library.baseUrl, allowIndefinite = library.reactivateDateNotRequired ?? false).then((r) => {
                                         resetGroup();
                                         onClose(onClose);
                                         startFreezing(false);

--- a/code/src/screens/MyAccount/TitlesOnHold/SelectThawDate.js
+++ b/code/src/screens/MyAccount/TitlesOnHold/SelectThawDate.js
@@ -37,13 +37,13 @@ export const SelectThawDate = (props) => {
           setDate(date);
           onClose();
           if (data) {
-               freezeHolds(data, libraryContext.baseUrl, date, language).then((result) => {
+               freezeHolds(data, libraryContext.baseUrl, date, language, libraryContext.allowIndefiniteHoldFreezes ?? false).then((result) => {
                     setLoading(false);
                     resetGroup();
                     hideDatePicker();
                });
           } else {
-               freezeHold(freezeId, recordId, source, libraryContext.baseUrl, userId, date, language).then((result) => {
+               freezeHold(freezeId, recordId, source, libraryContext.baseUrl, userId, date, language, libraryContext.allowIndefiniteHoldFreezes ?? false).then((result) => {
                     setLoading(false);
                     resetGroup();
                     hideDatePicker();

--- a/code/src/screens/MyAccount/TitlesOnHold/SelectThawDate.js
+++ b/code/src/screens/MyAccount/TitlesOnHold/SelectThawDate.js
@@ -37,13 +37,13 @@ export const SelectThawDate = (props) => {
           setDate(date);
           onClose();
           if (data) {
-               freezeHolds(data, libraryContext.baseUrl, date, language, libraryContext.allowIndefiniteHoldFreezes ?? false).then((result) => {
+               freezeHolds(data, libraryContext.baseUrl, date, language, libraryContext.reactivateDateNotRequired ?? false).then((result) => {
                     setLoading(false);
                     resetGroup();
                     hideDatePicker();
                });
           } else {
-               freezeHold(freezeId, recordId, source, libraryContext.baseUrl, userId, date, language, libraryContext.allowIndefiniteHoldFreezes ?? false).then((result) => {
+               freezeHold(freezeId, recordId, source, libraryContext.baseUrl, userId, date, language, libraryContext.reactivateDateNotRequired ?? false).then((result) => {
                     setLoading(false);
                     resetGroup();
                     hideDatePicker();

--- a/code/src/util/accountActions.js
+++ b/code/src/util/accountActions.js
@@ -377,7 +377,7 @@ export async function viewOverDriveItem(userId, formatId, overDriveId, url, lang
 }
 
 /* ACTIONS ON HOLDS */
-export async function freezeHold(cancelId, recordId, source, url, patronId, selectedReactivationDate = null, language = 'en') {
+export async function freezeHold(cancelId, recordId, source, url, patronId, selectedReactivationDate = null, language = 'en', allowIndefinite=false) {
      const postBody = await postData();
 
      const today = moment().format('YYYY-MM-DD');
@@ -387,9 +387,14 @@ export async function freezeHold(cancelId, recordId, source, url, patronId, sele
           if (reactivationDate === 'Invalid date') {
                reactivationDate = null;
           } else if (reactivationDate === today) {
-               reactivationDate = moment().add(30, 'days').format('YYYY-MM-DD');
+               if(allowIndefinite)
+               {
+                    reactivationDate = null;
+               } else {
+                    reactivationDate = moment().add(30, 'days').format('YYYY-MM-DD');
+               }
           }
-     } else {
+     } else if(!allowIndefinite) {
           reactivationDate = moment().add(30, 'days').format('YYYY-MM-DD');
      }
 
@@ -425,7 +430,7 @@ export async function freezeHold(cancelId, recordId, source, url, patronId, sele
      }
 }
 
-export async function freezeHolds(data, url, selectedReactivationDate = null, language = 'en') {
+export async function freezeHolds(data, url, selectedReactivationDate = null, language = 'en', allowIndefinite=false) {
      const postBody = await postData();
 
      const today = moment().format('YYYY-MM-DD');
@@ -435,9 +440,16 @@ export async function freezeHolds(data, url, selectedReactivationDate = null, la
           if (reactivationDate === 'Invalid date') {
                reactivationDate = null;
           } else if (reactivationDate === today) {
-               reactivationDate = moment().add(30, 'days').format('YYYY-MM-DD');
+               if(allowIndefinite)
+               {
+                    reactivationDate = null;
+               }
+               else 
+               {
+                    reactivationDate = moment().add(30, 'days').format('YYYY-MM-DD');
+               }
           }
-     } else {
+     } else if(!allowIndefinite) {
           reactivationDate = moment().add(30, 'days').format('YYYY-MM-DD');
      }
 

--- a/release-notes/26.03.00.MD
+++ b/release-notes/26.03.00.MD
@@ -4,3 +4,4 @@
 //kirstien
 
 //imani
+- Adding allowIndefinite to freezeHold and freezeHolds in account actions to allow null or today reactivation dates to be interpreted as indefinite hold freezes instead of default of 30 days to thaw. ((DIS-1652)[https://aspen-discovery.atlassian.net/browse/DIS-1652]) (*IT*)


### PR DESCRIPTION
to test:

- with the setting on discovery set to not allow indefinite holds, open LiDA and freeze a hold without selecting a date (may be default of today depending on device).
- 
-  hold should be frozen until 30 days out preserving old behavior
- 
- in discovery change the setting to turn on allowing indefinite holds
- 
- close LiDA and open it again
- 
- freeze a hold without selecting a date again.
- 
- This time the hold should be frozen without a thaw date specified

(This behavior depends on the companion discovery PR for DIS-1652. Without it you should only get the default 30 days out behavior but nothing should behave differently if you have this and not the discovery update.)