### PR TITLE
DIS-2171 graceful logout

### DIFF
--- a/code/src/screens/Auth/Loading.js
+++ b/code/src/screens/Auth/Loading.js
@@ -87,6 +87,12 @@ export const LoadingScreen = () => {
                await createGlueTheme(LIBRARY.url).then((result) => {
                     updateTheme(result);
                     setLoadingTheme(false);
+                    //if we have no library we should set error
+                    //to avoid being stuck on loading screen.
+                    if(LIBRARY.url === null)
+                    {
+                         setHasError(true);
+                    }
                });
           });
 

--- a/release-notes/26.05.00.MD
+++ b/release-notes/26.05.00.MD
@@ -4,3 +4,4 @@
 //mark
 
 //imani
+- Update loading screen focus listener to raise an error and return to login when we don't know what library we should be connecting to. ([DIS-2171](https://aspen-discovery.atlassian.net/browse/DIS-2171))


### PR DESCRIPTION
This is a bit difficult to test as the situations that cause it shouldn't happen but if Loading.js' navigation focus listener is called while we do not have a LIBRARY.url currently we will get stuck on a loading screen but with this change we will instead get an error message and be brought back to the login. 

The issues that could lead to this currently were fixed in 26.02 but this is a bit of a defensive update to have future issues fail a little more gracefully. 

to test you could inside of Loading.js in the navigation focus listener add a line to set LIBRARY.url equal to null. and observe that you get sent to the login screen. Without this change adding that line will cause the system to freeze on the loading screen.