### PR TITLE
DIS-2328 empty expiration date

### DIFF
--- a/code/src/screens/MyAccount/MyLibraryCard/MyLibraryCard.js
+++ b/code/src/screens/MyAccount/MyLibraryCard/MyLibraryCard.js
@@ -328,7 +328,11 @@ const CreateLibraryCard = (data) => {
      }
 
      let expirationDate = null;
-     if (!_.isUndefined(card.expires) && !_.isNull(card.expires)) {
+     if (!_.isUndefined(card.expires) 
+          && !_.isNull(card.expires)
+          && (card.expires !== "")
+          && (card.expires !== "Dec 31, 1969")) {
+               
           if (_.isString(card.expires)) {
                expirationDate = moment(card.expires, 'MMM D, YYYY');
           }

--- a/release-notes/26.05.00.MD
+++ b/release-notes/26.05.00.MD
@@ -4,3 +4,4 @@
 //mark
 
 //imani
+- Added empty string and Dec 31 1969 (linux epoch -1) as values for the null and undefined check for card expiration dates ([DIS-2328](https://aspen-discovery.atlassian.net/browse/DIS-2328)) (*IT*)


### PR DESCRIPTION
tested with Sierra on accounts with no expiration date.

Before the change we were seeing expiration Dec 31, 1969 in Lida.
After the change there was no expiration date shown. 