### PR TITLE
DIS-2348 hold crash

### DIFF
--- a/code/src/components/Action/Holds/HoldPrompt.js
+++ b/code/src/components/Action/Holds/HoldPrompt.js
@@ -479,7 +479,7 @@ export const HoldPrompt = (props) => {
                                         colorMode={colorMode}
                                    />
                               ) : null}
-                              {!isFetching && _.isEmpty(volumeId) && (typeOfHold === 'either' || typeOfHold === 'item') ? <SelectItemHold theme={theme} colorMode={colorMode} id={id} item={item} setItem={setItem} language={language} data={data} holdType={holdType} setHoldType={setHoldType} holdTypeForFormat={holdTypeForFormat} url={library.baseUrl} showModal={showModal} textColor={textColor} /> : null}
+                              {data !== undefined && !isFetching && _.isEmpty(volumeId) && (typeOfHold === 'either' || typeOfHold === 'item') ? <SelectItemHold theme={theme} colorMode={colorMode} id={id} item={item} setItem={setItem} language={language} data={data} holdType={holdType} setHoldType={setHoldType} holdTypeForFormat={holdTypeForFormat} url={library.baseUrl} showModal={showModal} textColor={textColor} /> : null}
                               {promptForHoldType || (holdType === 'volume' && _.isEmpty(volumeId)) ? <SelectVolume theme={theme} id={id} language={language} volume={volume} setVolume={setVolume} promptForHoldType={promptForHoldType} holdType={holdType} setHoldType={setHoldType} showModal={showModal} url={library.baseUrl} textColor={textColor} colorMode={colorMode}  /> : null}
                               {(_.isArray(locations) && (_.size(locations) > 1 || !preferredPickupLocationIsValid) && !isEContent && !user.rememberHoldPickupLocation) || (_.isArray(locations) && _.size(locations) > 1 && !isEContent && _.size(accounts) > 0) ? (
                                    <FormControl mt="$1">

--- a/release-notes/26.05.00.MD
+++ b/release-notes/26.05.00.MD
@@ -4,3 +4,4 @@
 //mark
 
 //imani
+- Checking if we have data before we call SelectItemHold to avoid crashes. ([DIS-2348](https://aspen-discovery.atlassian.net/browse/DIS-2348)) (*IT*)


### PR DESCRIPTION
This is a bit awkard to test because it depends on a weird data state. https://ramapo.aspendiscovery.org/Record/32979?searchId=27947270&recordIndex=3&page=1&referred=resultIndex  the second entry for Horton hears a who from Ramapo has undefined data going into hold Prompt. if you can simulate this state and place a hold on the item without this change LiDA crashes but after this change the later sections of HoldPrompt carry out the Hold.

In this case I believe some items in the grouped work had volume data and some did not. 

All other hold prompts should be unaffected. 