### PR TITLE
DIS-2134 pickup location

### DIFF
--- a/code/src/components/Action/Holds/PlaceHold.js
+++ b/code/src/components/Action/Holds/PlaceHold.js
@@ -45,7 +45,7 @@ export const PlaceHold = (props) => {
           userHasAlternateLibraryCard,
           shouldPromptAlternateLibraryCard
      } = props;
-     const { user, accounts, locations} = React.useContext(UserContext);
+     const { user, accounts, locations, preferredPickupLocationIsValid} = React.useContext(UserContext);
      const { library } = React.useContext(LibrarySystemContext);
      const { location } = React.useContext(LibraryBranchContext);
      const [loading, setLoading] = React.useState(false);
@@ -80,7 +80,7 @@ export const PlaceHold = (props) => {
      let promptForHoldNotifications = user.promptForHoldNotifications ?? false;
 
      let loadHoldPrompt = false;
-     if (!user.preferredPickupLocationIsValid) {
+     if (!preferredPickupLocationIsValid) {
           logDebugMessage("Showing Hold Prompt because the user's preferred pickup location is invalid");
           loadHoldPrompt = true;
      }else if (volumeInfo.numItemsWithVolumes >= 1 && _.isEmpty(volumeId)) {

--- a/release-notes/26.06.00.MD
+++ b/release-notes/26.06.00.MD
@@ -4,3 +4,4 @@
 //kirstien
 
 //imani
+- replaced user.preferredPickupLocationIsValid in PlaceHold with accurate value from preferredPickupLocationIsValid ([DIS-2134](https://aspen-discovery.atlassian.net/browse/DIS-2134)) (*IT*)


### PR DESCRIPTION
- enable bypass pickup location prompt for a user
- place a hold for them in LiDA
- prior to this change was getting a blank hold options modal like the attached image
- after this change we should properly skip the modal and process the hold immediately

issue: https://aspen-discovery.atlassian.net/browse/DIS-2134