### PR TITLE
Fix startup hangs and loading failures introduced with the 26.06 fetch client

### DIFF
--- a/code/App.js
+++ b/code/App.js
@@ -19,6 +19,7 @@ import { createTheme, saveTheme } from './src/themes/theme';
 
 import { logDebugMessage, logInfoMessage, logWarnMessage, logErrorMessage } from './src/util/logging.js';
 import { initDatabase } from './src/util/db/sqlite';
+import { purgeExpiredApiErrorLogs } from './src/util/db';
 
 logDebugMessage("1 Enabling Screens, react-native-screens");
 enableScreens();
@@ -69,6 +70,11 @@ export default function AppContainer() {
           (async () => {
                try {
                     await initDatabase();
+                    // trim old API log rows in the background; without this the table grows
+                    // unbounded (a row per API error) and slows every write on the request path
+                    purgeExpiredApiErrorLogs(24).catch((e) => {
+                         logDebugMessage('Could not purge expired API error logs: ' + e);
+                    });
                } catch (error) {
                     logErrorMessage('Failed to initialize SQLite');
                     logErrorMessage(error);
@@ -108,21 +114,27 @@ export default function AppContainer() {
 
                if (colorMode) {
                     logDebugMessage("5 Creating Theme ");
-                    await createTheme(colorMode).then(async (result) => {
-                         logDebugMessage("5a retrieved data from createTheme");
-                         setAspenTheme(result);
-                         updateTheme(result);
-                         logDebugMessage("5b Set Aspen Theme");
-                         if (result.colors?.primary['baseContrast'] === '#000000') {
-                              setStatusBarColor('dark-content');
-                         } else {
-                              setStatusBarColor('light-content');
-                         }
-                         logDebugMessage("5c Saving Theme");
-                         await saveTheme(result);
-                    });
-
-                    setLoading(false);
+                    try {
+                         await createTheme(colorMode).then(async (result) => {
+                              logDebugMessage("5a retrieved data from createTheme");
+                              setAspenTheme(result);
+                              updateTheme(result);
+                              logDebugMessage("5b Set Aspen Theme");
+                              if (result.colors?.primary?.['baseContrast'] === '#000000') {
+                                   setStatusBarColor('dark-content');
+                              } else {
+                                   setStatusBarColor('light-content');
+                              }
+                              logDebugMessage("5c Saving Theme");
+                              await saveTheme(result);
+                         });
+                    } catch (e) {
+                         // never leave the app stuck on the splash screen because theming failed
+                         logErrorMessage('Could not create theme, continuing with defaults');
+                         logErrorMessage(e);
+                    } finally {
+                         setLoading(false);
+                    }
                }
           };
           setupNativeBaseTheme().then(() => {

--- a/code/src/components/AddToWalletButton.js
+++ b/code/src/components/AddToWalletButton.js
@@ -1,0 +1,101 @@
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { Button, ButtonIcon, ButtonText, Spinner } from '@gluestack-ui/themed';
+import * as FileSystem from 'expo-file-system';
+import * as Linking from 'expo-linking';
+import * as Sharing from 'expo-sharing';
+import React from 'react';
+import { Platform } from 'react-native';
+
+import { LibrarySystemContext, ThemeContext } from '../context/initialContext';
+import { fetchWalletPass } from '../util/api/user';
+import { logDebugMessage, logErrorMessage } from '../util/logging';
+import { popToast } from './loadError';
+
+/**
+ * "Add to Apple Wallet" / "Add to Google Wallet" button for the digital library card.
+ *
+ * Hidden unless the server advertises support via library.enableWalletPass (returned by
+ * SystemAPI getLibraryInfo — see WALLET-PASS-SPEC.md), so this component is safe to ship
+ * before the Aspen Discovery server side exists: it simply renders nothing. The optional
+ * library.walletPassPlatforms field ("apple", "google", or "apple,google") limits which
+ * platform shows the button; when absent, both are assumed.
+ *
+ * iOS flow:     UserAPI getPatronWalletPass (platform=apple) returns a base64-encoded,
+ *               server-signed .pkpass → written to the cache directory → handed to iOS via
+ *               the share sheet, which recognizes the pkpass UTI and offers "Add to Wallet".
+ * Android flow: UserAPI getPatronWalletPass (platform=google) returns a signed-JWT
+ *               "Save to Google Wallet" link (result.saveUrl) → opened with Linking; the
+ *               Google Wallet app (or browser fallback) handles the save.
+ * No native modules required on either platform.
+ *
+ * TODO before release: swap the styled button for the official "Add to Apple Wallet" /
+ * "Add to Google Wallet" badge artwork (required by both Apple's and Google's brand
+ * guidelines) and source the labels from translation terms.
+ */
+export const AddToWalletButton = (props) => {
+     const { card } = props;
+     const [isLoading, setIsLoading] = React.useState(false);
+     const { library } = React.useContext(LibrarySystemContext);
+     const { theme } = React.useContext(ThemeContext);
+
+     const platformKey = Platform.OS === 'ios' ? 'apple' : 'google';
+     const walletPassEnabled = library?.enableWalletPass === '1' || library?.enableWalletPass === 1 || library?.enableWalletPass === true;
+     const supportedPlatforms = String(library?.walletPassPlatforms ?? 'apple,google').toLowerCase();
+     if (!walletPassEnabled || !supportedPlatforms.includes(platformKey)) {
+          return null;
+     }
+
+     const barcode = card?.ils_barcode ?? card?.cat_username ?? null;
+     const buttonLabel = platformKey === 'apple' ? 'Add to Apple Wallet' : 'Add to Google Wallet';
+
+     const addToWallet = async () => {
+          setIsLoading(true);
+          try {
+               const response = await fetchWalletPass(library?.baseUrl, barcode, platformKey);
+               const result = response?.data?.result;
+
+               if (platformKey === 'google') {
+                    if (response?.ok && result?.success && result?.saveUrl) {
+                         // Google Wallet (or a browser fallback) handles the signed save link
+                         await Linking.openURL(result.saveUrl);
+                    } else {
+                         const message = result?.message ?? 'The library card pass could not be created. Please try again or contact the library.';
+                         popToast('Unable to add card to Wallet', message, 'error');
+                         logDebugMessage(response);
+                    }
+               } else if (response?.ok && result?.success && result?.passData) {
+                    const fileUri = FileSystem.cacheDirectory + (result.fileName ?? 'library-card.pkpass');
+                    await FileSystem.writeAsStringAsync(fileUri, result.passData, { encoding: FileSystem.EncodingType.Base64 });
+
+                    if (await Sharing.isAvailableAsync()) {
+                         await Sharing.shareAsync(fileUri, {
+                              UTI: 'com.apple.pkpass',
+                              mimeType: 'application/vnd.apple.pkpass',
+                              dialogTitle: 'Add to Apple Wallet',
+                         });
+                    } else {
+                         popToast('Unable to open pass', 'Sharing is not available on this device.', 'error');
+                    }
+               } else {
+                    // the server explains failures it can predict, e.g. a barcode format
+                    // Apple Wallet cannot render (CODE39) — surface its message when present
+                    const message = result?.message ?? 'The library card pass could not be created. Please try again or contact the library.';
+                    popToast('Unable to add card to Wallet', message, 'error');
+                    logDebugMessage(response);
+               }
+          } catch (e) {
+               logErrorMessage('Error adding card to wallet');
+               logErrorMessage(e);
+               popToast('Unable to add card to Wallet', 'An unexpected error occurred. Please try again.', 'error');
+          } finally {
+               setIsLoading(false);
+          }
+     };
+
+     return (
+          <Button mt="$2" size="sm" variant="outline" isDisabled={isLoading || !barcode} onPress={addToWallet}>
+               {isLoading ? <Spinner size="small" mr="$1" /> : <ButtonIcon mr="$1" as={MaterialCommunityIcons} name="wallet-plus" color={theme['colors']['primary']['500']} />}
+               <ButtonText color={theme['colors']['primary']['500']}>{buttonLabel}</ButtonText>
+          </Button>
+     );
+};

--- a/code/src/components/navigation.js
+++ b/code/src/components/navigation.js
@@ -147,6 +147,10 @@ export function App() {
      );
 
      React.useEffect(() => {
+          // Check for OTA updates every 15 minutes. The previous 10 SECOND interval hammered
+          // the update servers and could trigger Updates.reloadAsync() while a patron was
+          // mid-task, which reads as a random crash/black screen.
+          const OTA_CHECK_INTERVAL = 15 * 60 * 1000;
           const timer = setInterval(async () => {
                if (!__DEV__) {
                     try {
@@ -168,7 +172,7 @@ export function App() {
                          // error checking for updates
                     }
                }
-          }, 10000);
+          }, OTA_CHECK_INTERVAL);
           return () => {
                clearInterval(timer);
           };
@@ -181,56 +185,70 @@ export function App() {
                let libraryUrl;
                let userKey;
                try {
-                    // Restore token stored in `AsyncStorage`
-                    userToken = await AsyncStorage.getItem('@userToken');
-                    libraryUrl = await AsyncStorage.getItem('@pathUrl');
-                    userKey = await SecureStore.getItemAsync('userKey');
-               } catch (e) {
-                    // Restoring token failed
-                    logErrorMessage("Error restoring token");
-                    logErrorMessage(e);
-                    dispatch({ type: 'SIGN_OUT' });
-               }
-
-               if (!userKey) {
-                    dispatch({ type: 'SIGN_OUT' });
-               }
-
-               if (!libraryUrl) {
-                    libraryUrl = LIBRARY.url;
-               }
-
-               if (userToken) {
-                    logDebugMessage('Session found');
-                    if (libraryUrl) {
-                         logDebugMessage('Trying to connect to: ', libraryUrl);
-                         await checkCachedUrl(libraryUrl).then(async (result) => {
-                              if (result) {
-                                   LIBRARY.url = libraryUrl;
-                                   logDebugMessage('Connection successful. Continuing...');
-                                   await trackAppLaunches(libraryUrl);
-                              } else {
-                                   logWarnMessage('Connection failed, logging out.');
-                                   userToken = null;
-                                   await RemoveData(queryClient, updateUser).then((res) => {
-                                        dispatch({ type: 'SIGN_OUT' });
-                                   });
-                              }
-                         });
-                    } else {
-                         logWarnMessage('No cached library url, logging out.');
-                         await RemoveData(queryClient, updateUser).then((res) => {
-                              dispatch({ type: 'SIGN_OUT' });
-                         });
+                    try {
+                         // Restore token stored in `AsyncStorage`
+                         userToken = await AsyncStorage.getItem('@userToken');
+                         libraryUrl = await AsyncStorage.getItem('@pathUrl');
+                         userKey = await SecureStore.getItemAsync('userKey');
+                    } catch (e) {
+                         // Restoring token failed
+                         logErrorMessage("Error restoring token");
+                         logErrorMessage(e);
+                         dispatch({ type: 'SIGN_OUT' });
                     }
-               } else {
-                    logDebugMessage('No session found. Starting new.');
+
+                    if (!userKey) {
+                         dispatch({ type: 'SIGN_OUT' });
+                    }
+
+                    if (!libraryUrl) {
+                         libraryUrl = LIBRARY.url;
+                    }
+
+                    if (userToken) {
+                         logDebugMessage('Session found');
+                         if (libraryUrl) {
+                              logDebugMessage('Trying to connect to: ', libraryUrl);
+                              await checkCachedUrl(libraryUrl).then(async (result) => {
+                                   if (result.connected) {
+                                        LIBRARY.url = libraryUrl;
+                                        logDebugMessage('Connection successful. Continuing...');
+                                        await trackAppLaunches(libraryUrl);
+                                   } else if (result.transient) {
+                                        // Network blip or slow server: keep the session instead of forcing
+                                        // the user to re-select their library and re-enter their card.
+                                        // If the server is genuinely down, the Loading screen surfaces the error.
+                                        LIBRARY.url = libraryUrl;
+                                        logWarnMessage('Could not verify library connection (transient network issue); keeping session.');
+                                   } else {
+                                        logWarnMessage('Connection failed, logging out.');
+                                        userToken = null;
+                                        await RemoveData(queryClient, updateUser).then((res) => {
+                                             dispatch({ type: 'SIGN_OUT' });
+                                        });
+                                   }
+                              });
+                         } else {
+                              logWarnMessage('No cached library url, logging out.');
+                              await RemoveData(queryClient, updateUser).then((res) => {
+                                   dispatch({ type: 'SIGN_OUT' });
+                              });
+                         }
+                    } else {
+                         logDebugMessage('No session found. Starting new.');
+                    }
+               } catch (e) {
+                    // Never leave the app stuck on the splash screen: fall through and restore
+                    // whatever token state we have (null token simply shows the login screen).
+                    logErrorMessage('Error during session bootstrap');
+                    logErrorMessage(e);
+               } finally {
+                    dispatch({
+                         type: 'RESTORE_TOKEN',
+                         token: userToken,
+                         refreshData: true,
+                    });
                }
-               dispatch({
-                    type: 'RESTORE_TOKEN',
-                    token: userToken,
-                    refreshData: true,
-               });
           };
           bootstrapAsync();
      }, []);

--- a/code/src/helpers/helpers.js
+++ b/code/src/helpers/helpers.js
@@ -300,7 +300,8 @@ export function generateSwatches(swatch) {
      const SATURATION_MAP = [0.32, 0.16, 0.08, 0.04, 0, 0, 0.04, 0.08, 0.16, 0.32];
      const HUE_MAP = [0, 4, 8, 12, 16, 20, 24, 28, 32, 36];
 
-     let primaryColor = swatch.replace('#', '');
+     // Server themes can return null/undefined colors; never crash the boot path over one
+     let primaryColor = typeof swatch === 'string' ? swatch.replace('#', '') : '';
      if (!chroma.valid(primaryColor)) {
           primaryColor = '#C70833';
      }

--- a/code/src/screens/Auth/Loading.js
+++ b/code/src/screens/Auth/Loading.js
@@ -87,16 +87,23 @@ export const LoadingScreen = () => {
                     updateColorMode('light');
                }
 
-               await createGlueTheme(LIBRARY.url).then((result) => {
-                    updateTheme(result);
+               try {
+                    await createGlueTheme(LIBRARY.url).then((result) => {
+                         updateTheme(result);
+                    });
+               } catch (e) {
+                    // continue with the current theme rather than freezing the loading chain
+                    logErrorMessage('Error creating theme on Loading screen');
+                    logErrorMessage(e);
+               } finally {
+                    // the query chain is gated on loadingTheme — it must ALWAYS be released
                     setLoadingTheme(false);
                     //if we have no library we should set error
                     //to avoid being stuck on loading screen.
-                    if(LIBRARY.url === null)
-                    {
+                    if (!LIBRARY.url) {
                          setHasError(true);
                     }
-               });
+               }
           });
 
           return unsubscribe;
@@ -129,7 +136,7 @@ export const LoadingScreen = () => {
                     }else if (LIBRARY.appSettings.loadingMessageType == 2) {
                          setLoadingText(LIBRARY.appSettings.loadingMessage);
                     }
-                    setProgress(progress + (100 / numSteps));
+                    setProgress((prev) => prev + 100 / numSteps);
                } else {
                     logWarnMessage("Setting Error to true because catalog status returned not ok");
                     const error = getErrorMessage(data.code ?? 0, data.problem);
@@ -153,7 +160,7 @@ export const LoadingScreen = () => {
      const { isSuccess: translationQuerySuccess, status: translationQueryStatus, data: translationQuery } = useQuery(['active_language', PATRON.language, LIBRARY.url], () => getTranslatedTermsForUserPreferredLanguage(PATRON.language ?? 'en', LIBRARY.url), {
           enabled: !!LIBRARY.url && catalogStatusSuccess,
           onSuccess: (data) => {
-               setProgress(progress + (100 / numSteps));
+               setProgress((prev) => prev + 100 / numSteps);
                updateDictionary(translationsLibrary);
                if (isUndefined(LIBRARY.appSettings.loadingMessageType) || LIBRARY.appSettings.loadingMessageType == 0) {
                     setLoadingText(getTermFromDictionary(language ?? 'en', 'loading_1'));
@@ -174,7 +181,7 @@ export const LoadingScreen = () => {
           enabled: hasError === false && catalogStatusSuccess,
           onSuccess: (data) => {
                if(data.ok) {
-                    setProgress(progress + (100 / numSteps));
+                    setProgress((prev) => prev + 100 / numSteps);
                     let languages = [];
                     if (data?.data?.result) {
                          logDebugMessage('Library languages saved at Loading');
@@ -221,12 +228,22 @@ export const LoadingScreen = () => {
           };
      }, []);
 
+     /**
+      * The queries below used to run strictly sequentially (each gated on the previous
+      * one's success), which meant 14 round trips one after another — minutes of progress
+      * bar on a slow server. Only three real data dependencies exist:
+      *   user            → library_system + languages
+      *   linked_accounts → user + library_system
+      *   system_messages → library_system + library_location
+      * Everything else fans out in parallel as soon as the catalog status confirms
+      * the server is reachable.
+      */
      const { isSuccess: librarySystemQuerySuccess, status: librarySystemQueryStatus, data: librarySystemQuery } = useQuery(['library_system', LIBRARY.url], () => getLibraryInfo(LIBRARY.url, LIBRARY.id), {
-          enabled: hasError === false && languagesQuerySuccess,
+          enabled: hasError === false && catalogStatusSuccess,
           onSuccess: (data) => {
                if(data.ok) {
                     const library = data.data.result?.library ?? [];
-                    setProgress(progress + (100 / numSteps));
+                    setProgress((prev) => prev + 100 / numSteps);
                     logDebugMessage("Updating library from Loading screen");
                     updateLibrary(library);
                     if (LIBRARY.appSettings.loadingMessageType == 1) {
@@ -250,7 +267,7 @@ export const LoadingScreen = () => {
      });
 
      const { isSuccess: userQuerySuccess, status: userQueryStatus, data: userQuery } = useQuery(['user', LIBRARY.url, 'en'], () => refreshProfile(LIBRARY.url), {
-          enabled: hasError === false && librarySystemQuerySuccess,
+          enabled: hasError === false && librarySystemQuerySuccess && languagesQuerySuccess,
           onSuccess: (data) => {
                if(data.ok) {
                     const profile = data.data.result.profile ?? [];
@@ -263,7 +280,7 @@ export const LoadingScreen = () => {
                               logWarnMessage("Setting Error to true because profile response returned a success of false");
                               setHasError(true);
                          } else {
-                              setProgress(progress + (100 / numSteps));
+                              setProgress((prev) => prev + 100 / numSteps);
                               updateUser(profile);
                               updateLanguage(profile.interfaceLanguage ?? 'en');
                               updateLanguageDisplayName(getLanguageDisplayName(profile.interfaceLanguage ?? 'en', languages));
@@ -290,11 +307,11 @@ export const LoadingScreen = () => {
      });
 
      const { isSuccess: libraryLinksQuerySuccess, status: libraryLinksQueryStatus, data: libraryLinksQuery } = useQuery(['library_links', LIBRARY.url], () => getLibraryLinks(LIBRARY.url), {
-          enabled: hasError === false && userQuerySuccess,
+          enabled: hasError === false && catalogStatusSuccess,
           onSuccess: (data) => {
                if(data.ok) {
                     const links = data.data.result?.items ?? [];
-                    setProgress(progress + (100 / numSteps));
+                    setProgress((prev) => prev + 100 / numSteps);
                     updateMenu(links);
                     if (LIBRARY.appSettings.loadingMessageType == 1) {
                          setLoadingText('Loading Browse Categories');
@@ -318,10 +335,10 @@ export const LoadingScreen = () => {
      });
 
      const { isSuccess: browseCategoryQuerySuccess, status: browseCategoryQueryStatus, data: browseCategoryQuery } = useQuery(['browse_categories', LIBRARY.url, 'en', false], () => getHomeScreenFeed(5, LIBRARY.url), {
-          enabled: hasError === false && libraryLinksQuerySuccess,
+          enabled: hasError === false && catalogStatusSuccess,
           onSuccess: (data) => {
                if(data.ok) {
-                    setProgress(progress + (100 / numSteps));
+                    setProgress((prev) => prev + 100 / numSteps);
                     const result = data.data.result;
                     updateBrowseCategories(result.browseCategories);
                     updateMaxCategories(5);
@@ -348,11 +365,11 @@ export const LoadingScreen = () => {
      });
 
      const { isSuccess: browseCategoryListQuerySuccess, status: browseCategoryListQueryStatus, data: browseCategoryListQuery } = useQuery(['browse_categories_list', LIBRARY.url, 'en'], () => getBrowseCategoryListForUser(LIBRARY.url), {
-          enabled: hasError === false && browseCategoryQuerySuccess,
+          enabled: hasError === false && catalogStatusSuccess,
           onSuccess: (data) => {
                if(data.ok) {
                     const categories = _.sortBy(data.data.result, ['title']);
-                    setProgress(progress + (100 / numSteps));
+                    setProgress((prev) => prev + 100 / numSteps);
                     if (isUndefined(LIBRARY.appSettings.loadingMessageType) || LIBRARY.appSettings.loadingMessageType == 0) {
                          setLoadingText(getTermFromDictionary(language ?? 'en', 'loading_2'));
                     }else if (LIBRARY.appSettings.loadingMessageType == 1) {
@@ -378,11 +395,11 @@ export const LoadingScreen = () => {
      });
 
      const { isSuccess: libraryBranchQuerySuccess, status: libraryBranchQueryStatus, data: libraryBranchQuery } = useQuery(['library_location', LIBRARY.url, 'en'], () => getLocationInfo(LIBRARY.url), {
-          enabled: hasError === false && browseCategoryListQuerySuccess,
+          enabled: hasError === false && catalogStatusSuccess,
           onSuccess: (data) => {
                if(data.ok) {
                     const location = data.data.result?.location ?? [];
-                    setProgress(progress + (100 / numSteps));
+                    setProgress((prev) => prev + 100 / numSteps);
                     updateLocation(location);
                     if (LIBRARY.appSettings.loadingMessageType == 1) {
                          setLoadingText('Loading Library Locations');
@@ -406,13 +423,13 @@ export const LoadingScreen = () => {
      });
 
      const { isSuccess: selfCheckQuerySuccess, status: selfCheckQueryStatus, data: selfCheckQuery } = useQuery(['self_check_settings', LIBRARY.url, 'en'], () => getSelfCheckSettings(LIBRARY.url), {
-          enabled: hasError === false && libraryBranchQuerySuccess,
+          enabled: hasError === false && catalogStatusSuccess,
           onSuccess: (data) => {
                if(data.ok) {
                     const settings = data.data.result ?? [];
                     logDebugMessage("Self Check Settings");
                     logDebugMessage(settings);
-                    setProgress(progress + (100 / numSteps));
+                    setProgress((prev) => prev + 100 / numSteps);
                     if (LIBRARY.appSettings.loadingMessageType == 1) {
                          setLoadingText('Loading Self Check Information');
                     }
@@ -442,10 +459,10 @@ export const LoadingScreen = () => {
      });
 
      const { isSuccess: linkedAccountQuerySuccess, status: linkedAccountQueryStatus, data: linkedAccountQuery } = useQuery(['linked_accounts', user ?? [], cards ?? [], LIBRARY.url, 'en'], () => getLinkedAccounts(LIBRARY.url, 'en'), {
-          enabled: hasError === false && selfCheckQuerySuccess,
+          enabled: hasError === false && userQuerySuccess && librarySystemQuerySuccess,
           onSuccess: (data) => {
                if(data.ok) {
-                    setProgress(progress + (100 / numSteps));
+                    setProgress((prev) => prev + 100 / numSteps);
                     const linkedAccounts = formatLinkedAccounts(user, cards ?? [], library?.barcodeStyle ?? 'UNKNOWN', data.data.result.linkedAccounts);
                     updateLinkedAccounts(linkedAccounts.accounts);
                     updateLibraryCards(linkedAccounts.cards);
@@ -471,12 +488,12 @@ export const LoadingScreen = () => {
           }
      });
 
-     const { isSuccess: systemMessagesQuerySuccess, status: systemMessagesQueryStatus, data: systemMessagesQuery } = useQuery(['system_messages', LIBRARY.url], () => getSystemMessages(library.libraryId, location.locationId, LIBRARY.url), {
-          enabled: hasError === false && linkedAccountQuerySuccess,
+     const { isSuccess: systemMessagesQuerySuccess, status: systemMessagesQueryStatus, data: systemMessagesQuery } = useQuery(['system_messages', LIBRARY.url], () => getSystemMessages(library?.libraryId, location?.locationId, LIBRARY.url), {
+          enabled: hasError === false && librarySystemQuerySuccess && libraryBranchQuerySuccess,
           onSuccess: (data) => {
                if(data.ok) {
                     const messages = _.castArray(data.data.result?.systemMessages ?? {});
-                    setProgress(progress + (100 / numSteps));
+                    setProgress((prev) => prev + 100 / numSteps);
                     updateSystemMessages(messages);
                     setIsReloading(false);
                     if (LIBRARY.appSettings.loadingMessageType == 1) {
@@ -501,7 +518,7 @@ export const LoadingScreen = () => {
      });
 
      const { isSuccess: appPreferencesQuerySuccess, status: appPreferencesQueryStatus, data: appPreferencesQuery } = useQuery(['app_preferences', LIBRARY.url], () => getAppPreferencesForUser(LIBRARY.url, 'en'), {
-          enabled: hasError === false && systemMessagesQuerySuccess,
+          enabled: hasError === false && catalogStatusSuccess,
           onSuccess: (data) => {
                if(data.ok) {
                     const preferences = data.data.result ?? {
@@ -519,7 +536,7 @@ export const LoadingScreen = () => {
                          ],
                     }
                     updateAppPreferences(preferences);
-                    setProgress(progress + (100 / numSteps));
+                    setProgress((prev) => prev + 100 / numSteps);
                     setIsReloading(false);
                     if (LIBRARY.appSettings.loadingMessageType == 1) {
                          setLoadingText('Loading App Preferences');
@@ -543,11 +560,11 @@ export const LoadingScreen = () => {
      });
 
      const { isSuccess: notificationHistoryQuerySuccess, status: notificationHistoryQueryStatus, data: notificationHistoryQuery } = useQuery(['notification_history'], () => fetchNotificationHistory(1, 20, true, LIBRARY.url, 'en'), {
-          enabled: hasError === false && appPreferencesQuerySuccess,
+          enabled: hasError === false && catalogStatusSuccess,
           onSuccess: (data) => {
                if(data.ok) {
                     const notificationHistory = formatNotificationHistory(data.data.result)
-                    setProgress(progress + (100 / numSteps));
+                    setProgress((prev) => prev + 100 / numSteps);
                     updateNotificationHistory(notificationHistory);
                     updateInbox(notificationHistory?.inbox ?? []);
                     setIsReloading(false);
@@ -572,10 +589,28 @@ export const LoadingScreen = () => {
           }
      });
 
+     // with the queries running in parallel, wait for every one of them before navigating
+     // (previously the chain was sequential, so the last query implied all the others)
+     const allQueriesLoaded =
+          catalogStatusSuccess &&
+          translationQuerySuccess &&
+          languagesQuerySuccess &&
+          librarySystemQuerySuccess &&
+          userQuerySuccess &&
+          libraryLinksQuerySuccess &&
+          browseCategoryQuerySuccess &&
+          browseCategoryListQuerySuccess &&
+          libraryBranchQuerySuccess &&
+          selfCheckQuerySuccess &&
+          linkedAccountQuerySuccess &&
+          systemMessagesQuerySuccess &&
+          appPreferencesQuerySuccess &&
+          notificationHistoryQuerySuccess;
+
      React.useEffect(() => {
           if (
                !isReloading &&
-               notificationHistoryQueryStatus === 'success' &&
+               allQueriesLoaded &&
                !hasError &&
                catalogStatus === 0
           ) {
@@ -638,7 +673,7 @@ export const LoadingScreen = () => {
           }
      }, [
           isReloading,
-          notificationHistoryQueryStatus,
+          allQueriesLoaded,
           hasError,
           catalogStatus,
           hasIncomingUrlChanged,

--- a/code/src/screens/Auth/Login.js
+++ b/code/src/screens/Auth/Login.js
@@ -73,65 +73,71 @@ export const LoginScreen = () => {
      useFocusEffect(
           React.useCallback(() => {
                const bootstrapAsync = async () => {
-                    await getPermissions('statusCheck').then(async (result) => {
-                         if (result.success === false && result.status === 'undetermined' && GLOBALS.releaseChannel !== 'DEV' && Platform.OS === 'android') {
-                              setShouldRequestPermissions(true);
-                              setPermissionStatus(result.status);
-                         }
-
-                         if (result.status !== 'granted' && Platform.OS === 'ios') {
-                              setPermissionRequested(true);
-                              setPermissionStatus(result.status);
-                              await getPermissions('request');
-                         }
-                    });
-
-                    await fetchNearbyLibrariesFromGreenhouse().then((result) => {
-                         if (result.success) {
-                              setLibraries(result.libraries);
-                              if (!result.shouldShowSelectLibrary) {
-                                   if (result.libraries.length == 1) {
-                                        setShowShouldSelectLibrary(result.shouldShowSelectLibrary);
-                                        logInfoMessage('Automatically selecting library ' + result.libraries[0].displayName + ' based on geolocation');
-                                        updateSelectedLibrary(result.libraries[0]);
-                                   }else{
-                                        logInfoMessage('Found ' + result.libraries.length + ' libraries, but shouldShowSelectLibrary is false');
-                                        setShowShouldSelectLibrary(true);
-                                   }
-                              }else{
-                                   logInfoMessage('Found ' + result.libraries.length + ' libraries');
-                                   setShowShouldSelectLibrary(true);
+                    try {
+                         await getPermissions('statusCheck').then(async (result) => {
+                              if (result.success === false && result.status === 'undetermined' && GLOBALS.releaseChannel !== 'DEV' && Platform.OS === 'android') {
+                                   setShouldRequestPermissions(true);
+                                   setPermissionStatus(result.status);
                               }
-                         }
-                    });
 
-                    await AsyncStorage.getItem('@colorMode').then(async (mode) => {
-                         if (mode === 'light' || mode === 'dark') {
-                              updateColorMode(mode);
-                         } else {
-                              updateColorMode('light');
-                         }
-                    });
-
-                    await createGlueTheme(Constants.expoConfig.extra.apiUrl).then((result) => {
-                         updateTheme(result);
-                    });
-
-                    if (isCommunity) {
-                         await fetchAllLibrariesFromGreenhouse().then((response) => {
-                              if(response.success) {
-                                   const libraries = _.sortBy(response.libraries ?? [], ['name', 'librarySystem']);
-                                   setAllLibraries(libraries);
-                              } else {
-                                   setAllLibraries([]);
-                                   logDebugMessage("Error loading libraries from Greenhouse");
-                                   logDebugMessage(response);
-                                   getErrorMessage(response.code ?? 0, response.problem)
+                              if (result.status !== 'granted' && Platform.OS === 'ios') {
+                                   setPermissionRequested(true);
+                                   setPermissionStatus(result.status);
+                                   await getPermissions('request');
                               }
                          });
-                    }
 
-                    setIsLoading(false);
+                         await fetchNearbyLibrariesFromGreenhouse().then((result) => {
+                              if (result.success) {
+                                   setLibraries(result.libraries);
+                                   if (!result.shouldShowSelectLibrary) {
+                                        if (result.libraries.length == 1) {
+                                             setShowShouldSelectLibrary(result.shouldShowSelectLibrary);
+                                             logInfoMessage('Automatically selecting library ' + result.libraries[0].displayName + ' based on geolocation');
+                                             updateSelectedLibrary(result.libraries[0]);
+                                        }else{
+                                             logInfoMessage('Found ' + result.libraries.length + ' libraries, but shouldShowSelectLibrary is false');
+                                             setShowShouldSelectLibrary(true);
+                                        }
+                                   }else{
+                                        logInfoMessage('Found ' + result.libraries.length + ' libraries');
+                                        setShowShouldSelectLibrary(true);
+                                   }
+                              }
+                         });
+
+                         await AsyncStorage.getItem('@colorMode').then(async (mode) => {
+                              if (mode === 'light' || mode === 'dark') {
+                                   updateColorMode(mode);
+                              } else {
+                                   updateColorMode('light');
+                              }
+                         });
+
+                         await createGlueTheme(Constants.expoConfig.extra.apiUrl).then((result) => {
+                              updateTheme(result);
+                         });
+
+                         if (isCommunity) {
+                              await fetchAllLibrariesFromGreenhouse().then((response) => {
+                                   if(response.success) {
+                                        const libraries = _.sortBy(response.libraries ?? [], ['name', 'librarySystem']);
+                                        setAllLibraries(libraries);
+                                   } else {
+                                        setAllLibraries([]);
+                                        logDebugMessage("Error loading libraries from Greenhouse");
+                                        logDebugMessage(response);
+                                        getErrorMessage(response.code ?? 0, response.problem)
+                                   }
+                              });
+                         }
+                    } catch (e) {
+                         // never leave the login screen stuck on the splash spinner
+                         logDebugMessage('Error during login screen bootstrap');
+                         logDebugMessage(e);
+                    } finally {
+                         setIsLoading(false);
+                    }
                };
                bootstrapAsync().then(() => {
                     return () => bootstrapAsync();

--- a/code/src/screens/MyAccount/MyLibraryCard/MyLibraryCard.js
+++ b/code/src/screens/MyAccount/MyLibraryCard/MyLibraryCard.js
@@ -13,6 +13,7 @@ import { Extrapolate, interpolate, useAnimatedStyle, useSharedValue } from 'reac
 import Carousel from 'react-native-reanimated-carousel';
 
 // custom components and helper files
+import { AddToWalletButton } from '../../../components/AddToWalletButton';
 import { PermissionsPrompt } from '../../../components/PermissionsPrompt';
 import { LanguageContext, LibrarySystemContext, ThemeContext, UserContext } from '../../../context/initialContext';
 import { navigateStack } from '../../../helpers/RootNavigator';
@@ -450,6 +451,7 @@ const CreateLibraryCard = (data) => {
                               <Text color={textColor} fontSize="$xl" textAlign="center">{barcodeValue}</Text>
                          </VStack>
                     )}
+                    <AddToWalletButton card={card} />
                     {showExpirationDate && expirationDate && !neverExpires && numCards === 1 ? (
                          <Text color={textColor} fontSize="$sm" pt="$2">
                               {expirationText}

--- a/code/src/themes/theme.js
+++ b/code/src/themes/theme.js
@@ -8,14 +8,64 @@ import { ThemeContext } from '../context/initialContext';
 
 import { logDebugMessage, logErrorMessage } from '../util/logging.js';
 import { getThemeInfo } from '../util/api/system';
+import { generateSwatches } from '../helpers/helpers';
 
 export const BackIcon = (props) => {
      const { theme } = React.useContext(ThemeContext);
      return <ChevronLeftIcon size="md" ml={1} {...props} color={theme['colors']['primary']['baseContrast']} />;
 };
 
+const BACKUP_COLOR_SCHEMES = ['#3dbdd6', '#9acf87', '#c1adcc'];
+
+/**
+ * Read the swatches cached by saveTheme() on a previous launch.
+ * Returns [primary, secondary, tertiary] palettes, or null if the cache is absent/corrupt.
+ */
+async function loadCachedSwatches() {
+     try {
+          const entries = await AsyncStorage.multiGet(['primaryColors', 'secondaryColors', 'tertiaryColors']);
+          const palettes = entries.map(([, value]) => (value ? JSON.parse(value) : null));
+          if (palettes.every((palette) => palette && typeof palette === 'object')) {
+               logDebugMessage('Using cached theme colors for instant boot');
+               return palettes;
+          }
+     } catch (e) {
+          logErrorMessage('Unable to read cached theme colors');
+          logErrorMessage(e);
+     }
+     return null;
+}
+
+/**
+ * Fetch theme swatches for the boot path. Strategy:
+ * 1. cached palettes from the last launch (instant — no network on the splash screen),
+ *    refreshing the cache in the background for the next launch;
+ * 2. otherwise fetch from the server;
+ * 3. otherwise the backup palette. Never rejects — if this throws, the splash/loading
+ *    screens never resolve.
+ */
+async function getThemeInfoSafe(url = null) {
+     try {
+          const cached = await loadCachedSwatches();
+          if (cached) {
+               // background refresh; worst case the theme is one launch behind the server
+               getThemeInfo(url)
+                    .then((fresh) => saveTheme({ colors: { primary: fresh[0], secondary: fresh[1], tertiary: fresh[2] } }))
+                    .catch((e) => {
+                         logDebugMessage('Background theme refresh failed: ' + e);
+                    });
+               return cached;
+          }
+          return await getThemeInfo(url);
+     } catch (e) {
+          logErrorMessage('Failed to load theme info, using backup theme');
+          logErrorMessage(e);
+          return BACKUP_COLOR_SCHEMES.map(generateSwatches);
+     }
+}
+
 export async function createTheme(colorMode) {
-     const response = await getThemeInfo();
+     const response = await getThemeInfoSafe();
      const theme = extendTheme({
           colors: {
                primary: response[0],
@@ -36,7 +86,7 @@ export async function createTheme(colorMode) {
 }
 
 export async function createGlueTheme(url) {
-     const response = await getThemeInfo(url);
+     const response = await getThemeInfoSafe(url);
      const theme = extendTheme({
           colors: {
                primary: response[0],

--- a/code/src/util/api/apiClient.js
+++ b/code/src/util/api/apiClient.js
@@ -7,6 +7,21 @@ import { API_KEY_1, API_KEY_2, API_KEY_3, API_KEY_4, API_KEY_5 } from '@env';
 import * as Sentry from '@sentry/react-native';
 import { insertApiErrorLog } from '../db';
 
+/**
+ * Write an API log entry without ever throwing or blocking the request path.
+ * A failed SQLite write (locked db, missing table during first-launch migration,
+ * full disk) must never turn an API response into a rejected promise.
+ */
+function safeInsertApiErrorLog(details) {
+     try {
+          insertApiErrorLog(details).catch((e) => {
+               logDebugMessage('Failed to write API error log entry: ' + e);
+          });
+     } catch (e) {
+          logDebugMessage('Failed to write API error log entry: ' + e);
+     }
+}
+
 const ERROR_TYPES = {
      TIMEOUT: 'TIMEOUT_ERROR',
      CONNECTION: 'CONNECTION_ERROR',
@@ -217,8 +232,8 @@ export class ApiClient {
                          logErrorMessage("Could not parse response from " + url + " as json");
                          logErrorMessage("Raw body causing error: " + rawText);
 
+                         // leave data null; validateAspenResponse flags this as INVALID_RESPONSE_TYPE below
                          data = null;
-                         isResponseOk = false;
                     }
                } else if (contentType?.includes('text')) {
                     data = await response.text();
@@ -271,7 +286,7 @@ export class ApiClient {
                      * if the response contains debug information.
                      */
                     if (this.debugMode || data.debug || data.result?.debug) {
-                         await insertApiErrorLog({
+                         safeInsertApiErrorLog({
                               method: options.method,
                               endpoint: url,
                               status: response.status || null,
@@ -342,8 +357,8 @@ export class ApiClient {
                     });
                }
 
-               // Log all API errors to the database
-               await insertApiErrorLog(errorDetails);
+               // Log all API errors to the database (fire-and-forget; must never throw or reject)
+               safeInsertApiErrorLog(errorDetails);
 
                if (config.customErrorMessage) {
                     logDebugMessage(config.customErrorMessage);

--- a/code/src/util/api/greenhouse.js
+++ b/code/src/util/api/greenhouse.js
@@ -135,7 +135,9 @@ export async function fetchAllLibrariesFromGreenhouse() {
      });
 
      if (response.ok) {
-          const libraries = [...(response.data.libraries ?? [])].sort((a, b) => {
+          // libraries live under result, same as fetchNearbyLibrariesFromGreenhouse above;
+          // reading response.data.libraries returned undefined and made the list permanently empty
+          const libraries = [...(response.data?.result?.libraries ?? [])].sort((a, b) => {
                if (a.name !== b.name) return (a.name ?? '').localeCompare(b.name ?? '');
                return (a.librarySystem ?? '').localeCompare(b.librarySystem ?? '');
           });

--- a/code/src/util/api/system.js
+++ b/code/src/util/api/system.js
@@ -137,11 +137,15 @@ export async function getAppSettings(url, timeout, slug) {
 
           logWarnMessage(`Did not get valid response from getAppSettings url: ${url} slug: ${slug}`);
           logWarnMessage(response);
-          return [];
+          LIBRARY.appSettings = LIBRARY.appSettings ?? {};
+          return LIBRARY.appSettings;
      } catch (err) {
-          popToast(getTermFromDictionary('en', 'error_no_server_connection'), 'Could not retrieve App Settings, please try again later.', 'error');
+          // note: getTermFromDictionary was referenced here without being imported, which made this
+          // catch block itself throw a ReferenceError; use the static English term instead
+          popToast('Unable to connect to the library', 'Could not retrieve App Settings, please try again later.', 'error');
           logErrorMessage(`Exception in getAppSettings ${err}`);
-          return [];
+          LIBRARY.appSettings = LIBRARY.appSettings ?? {};
+          return LIBRARY.appSettings;
      }
 }
 
@@ -255,14 +259,22 @@ export async function getLocations(url = null, language = 'en', latitude, longit
 }
 
 /**
- * Check if the provided URL is valid and has a working connection to Aspen Discovery by making a test API call
+ * Check if the provided URL is valid and has a working connection to Aspen Discovery by making a test API call.
+ * Distinguishes transient connectivity problems (timeout, dropped connection) from a genuinely
+ * dead/invalid url so callers don't destroy a valid session over a network blip.
  * @param url
- * @returns {Promise<boolean>}
+ * @returns {Promise<{connected: boolean, transient: boolean}>}
  */
 export async function checkCachedUrl(url) {
-     const client = createApiClient({ url, timeout: GLOBALS.timeoutFast });
+     // boot-critical: with the old 30s timeout (plus a retry) users stared at the splash
+     // screen for up to a minute before anything happened
+     const client = createApiClient({ url, timeout: GLOBALS.timeoutBoot });
      const response = await client.post('/SystemAPI?method=getCatalogStatus');
-     return !!response.ok;
+     const transientProblems = ['TIMEOUT_ERROR', 'CONNECTION_ERROR', 'NETWORK_ERROR'];
+     return {
+          connected: !!response.ok,
+          transient: !response.ok && transientProblems.includes(response.problem),
+     };
 }
 
 /**

--- a/code/src/util/api/user.js
+++ b/code/src/util/api/user.js
@@ -39,6 +39,32 @@ export async function refreshProfile(url = null) {
 }
 
 /**
+ * Fetch a wallet pass for the patron's library card (see WALLET-PASS-SPEC.md).
+ * Generated and signed server-side. For platform 'apple' the response carries a
+ * base64-encoded .pkpass in result.passData; for platform 'google' it carries a
+ * signed-JWT "Save to Google Wallet" link in result.saveUrl.
+ * @param url
+ * @param barcode which card to build the pass for (supports linked accounts); null = primary
+ * @param platform 'apple' or 'google'
+ * @returns {Promise<*|{ok: boolean, status, problem: string, data, config: {}}|undefined>}
+ */
+export async function fetchWalletPass(url = null, barcode = null, platform = 'apple') {
+     const client = userClient(url, GLOBALS.timeoutAverage);
+     logDebugMessage('Fetching wallet pass for platform ' + platform);
+
+     return await client.post(
+          '/UserAPI?method=getPatronWalletPass',
+          {},
+          {
+               params: {
+                    platform,
+                    barcode,
+               },
+          }
+     );
+}
+
+/**
  * Refreshes the profile information for the user, forcing a reload from the ILS.
  * @param url
  * @returns {Promise<{success: boolean, errorFetching: boolean}|*>}

--- a/code/src/util/db/sqlite.js
+++ b/code/src/util/db/sqlite.js
@@ -3,18 +3,24 @@ import { versionUpdates, compareReleaseKeys } from './versionUpdates';
 import { logDebugMessage, logErrorMessage } from '../logging';
 
 const DB_NAME = 'aspen_lida.db';
-let dbInstance = null;
+let dbPromise = null;
 
 /**
  * Returns a singleton instance of the SQLite database connection.
- * If the connection has not been established yet, it will be created and stored for future use.
+ * The opening promise (not the instance) is cached so concurrent callers during
+ * startup share one connection instead of each opening their own, which caused
+ * "database is locked" errors on Android. If opening fails, the cache is cleared
+ * so a later call can retry.
  * @returns {Promise<*>}
  */
 export async function getDb() {
-     if (!dbInstance) {
-          dbInstance = await SQLite.openDatabaseAsync(DB_NAME);
+     if (!dbPromise) {
+          dbPromise = SQLite.openDatabaseAsync(DB_NAME).catch((error) => {
+               dbPromise = null;
+               throw error;
+          });
      }
-     return dbInstance;
+     return dbPromise;
 }
 
 /**

--- a/code/src/util/globals.js
+++ b/code/src/util/globals.js
@@ -12,6 +12,8 @@ export const GLOBALS = {
      timeoutAverage: 60000,
      timeoutSlow: 100000,
      timeoutFast: 30000,
+     // for boot-critical calls the user is staring at a splash screen; fail fast and fall back
+     timeoutBoot: 8000,
      appVersion: Constants.expoConfig.version,
      appBuild: Platform.OS === 'android' ? androidDist : iOSDist,
      appSessionId: Constants.expoConfig.sessionid,
@@ -123,6 +125,7 @@ export const LIBRARY = {
      localIll: [],
      id: 0,
      version: null,
+     appSettings: {},
 };
 
 export const BRANCH = {

--- a/code/src/util/logging.js
+++ b/code/src/util/logging.js
@@ -76,7 +76,33 @@ export function logSentryMessage(message, level = 'error') {
      }
 }
 
-export function getErrorMessage({ statusCode = null, problem, sendToSentry = false }) {
+/**
+ * Build a user-facing error message from an API failure.
+ * Accepts either positional arguments — getErrorMessage(statusCode, problem, sendToSentry) —
+ * which is how ~80 call sites invoke it, or a single options object —
+ * getErrorMessage({ statusCode, problem, sendToSentry }). The old object-only signature
+ * silently discarded the arguments at every positional call site, so users always saw
+ * the generic "An unexpected error occurred" message.
+ */
+export function getErrorMessage(statusCodeOrOptions = null, problemArg = undefined, sendToSentryArg = false) {
+     let statusCode = statusCodeOrOptions;
+     let problem = problemArg;
+     let sendToSentry = sendToSentryArg;
+
+     if (statusCodeOrOptions !== null && typeof statusCodeOrOptions === 'object') {
+          statusCode = statusCodeOrOptions.statusCode ?? null;
+          problem = statusCodeOrOptions.problem;
+          sendToSentry = statusCodeOrOptions.sendToSentry ?? false;
+     }
+
+     // treat non-string problems (objects passed by mistake) and 0/'' status codes as absent
+     if (typeof problem !== 'string' || problem === '') {
+          problem = undefined;
+     }
+     if (!statusCode) {
+          statusCode = null;
+     }
+
      let errorDetails;
      if (problem) {
           switch (problem) {


### PR DESCRIPTION
Built purely with Claude for fun. I am not a developer. Wallet DIS-480 only tested in Android. Claude notes:

# Aspen LiDA 26.06.00 — startup hang & loading fixes

Note on scope: 12 of the 15 files are the startup/loading fixes described below. The other
three (`AddToWalletButton.js` new, plus small additions to `user.js` and `MyLibraryCard.js`)
are an optional wallet-pass feature that ships fully gated — it renders nothing until a server
sends a new `enableWalletPass` flag (server-side contract documented in the component JSDoc; full spec available on request) — and can be split
into its own PR on request.

## Summary

Users across many libraries report LiDA "just spins and never loads" since 26.06 — see recent
Play Store reviews ("won't even come up, just spins", "reinstalled and still not working",
"takes 30–60 seconds to open", "constantly signs me out"). We traced the reports to a set of
interacting defects introduced or exposed by the 26.06 API-client rewrite (DIS-2413) and the
new SQLite API error log (DIS-2100), plus several long-standing issues that the rewrite made
more visible.

**Core mechanism:** the old apisauce client *never rejected* — it always resolved to
`{ok:false, problem}` — and the entire codebase was written against that contract (call sites
do not try/catch). The new custom fetch client can reject in several paths. When it does,
every boot flow (App.js, navigation.js bootstrap, Login.js bootstrap, Loading.js) stalls
before reaching its "stop showing the spinner" state, and the app hangs on the splash screen
forever.

---

## Part 1 — Correctness fixes (startup hangs, data loss)

### 1.1 `apiClient.js`: restore the "never rejects" contract
- `request()`'s catch block ended with `await insertApiErrorLog(errorDetails)`. If that SQLite
  write throws (locked DB, `api_error_logs` table not yet created during first-launch
  migration, full disk), the exception escapes the catch and **`request()` rejects instead of
  returning `{ok:false}`** — cascading into permanent splash screens. Same risk on the success
  path (`await insertApiErrorLog` when the response carries debug info).
- Fix: `safeInsertApiErrorLog()` — fire-and-forget, wrapped so it can never throw and never
  delays a response.
- Also removed `isResponseOk = false;` — an assignment to an **undeclared variable**
  (ReferenceError in strict mode) in the JSON-parse-failure branch. Leaving `data = null`
  lets the existing `validateAspenResponse` INVALID_RESPONSE_TYPE path handle it.

### 1.2 `sqlite.js`: `getDb()` caches the opening *promise*
Previously `dbInstance` was assigned only after `await openDatabaseAsync` resolved, so
concurrent first callers each opened their own connection → classic Android
"database is locked". The promise is now cached (and cleared on failure so a later call can
retry).

### 1.3 Boot flows: try/catch/finally so the spinner always resolves
- `App.js` — theme creation wrapped; `setLoading(false)` moved to `finally`.
- `components/navigation.js` bootstrap — whole body wrapped; `RESTORE_TOKEN` dispatched in
  `finally` (a null token simply shows the login screen instead of hanging).
- `screens/Auth/Login.js` bootstrap — wrapped; `setIsLoading(false)` in `finally`.
- `screens/Auth/Loading.js` focus handler — `createGlueTheme` wrapped; `setLoadingTheme(false)`
  in `finally` (the entire query chain is gated on it, so it must always be released). The
  "no library" guard now checks `!LIBRARY.url` — the previous `=== null` check never fired
  because `LIBRARY.url` defaults to `''`.

### 1.4 Theme pipeline can no longer reject
- `themes/theme.js` — `getThemeInfoSafe()` wrapper: falls back to the backup palette on any
  failure (both `createTheme` and `createGlueTheme`).
- `helpers.js` `generateSwatches()` — a server theme with a missing/null color caused
  `swatch.replace` to throw a TypeError, bricking startup for **every patron of that library**
  (matches "reinstalled and still not working" reviews — reinstalling can't fix server data).
  Non-string input now falls through to the existing `chroma.valid` fallback.
- `util/globals.js` — `LIBRARY.appSettings` defaults to `{}`; `Loading.js` dereferences
  `LIBRARY.appSettings.loadingMessageType` unguarded in ~12 callbacks.
- `util/api/system.js` `getAppSettings()` — failure paths now also populate
  `LIBRARY.appSettings`. **Bonus bug:** the catch block called `getTermFromDictionary`, which
  is not imported in system.js — the error handler itself threw a ReferenceError. Replaced
  with the static English string (importing TranslationService there would create a require
  cycle).

### 1.5 `navigation.js` + `system.js`: don't destroy the session on a network blip
`checkCachedUrl` returned a bare boolean, and **any** failure — a timeout, a dropped
connection, a slow ILS — triggered `RemoveData` + `SIGN_OUT`, forcing the patron to re-find
their library and re-enter their barcode. This is the single most repeated store-review
complaint ("about 50% of the time it would require searching for our library and re-inputting
the library card number"). `checkCachedUrl` now returns `{connected, transient}`; transient
problems (TIMEOUT/CONNECTION/NETWORK) keep the session and let the Loading screen surface any
real outage with a message. Only a genuinely dead/invalid URL signs the user out.

### 1.6 `greenhouse.js`: "find your library" list was always empty
`fetchAllLibrariesFromGreenhouse` read `response.data.libraries`; the payload nests them under
`response.data.result.libraries` (as `fetchNearbyLibrariesFromGreenhouse` in the same file
correctly does). Community-app users typing in the library search got zero results — matches
multiple reviews ("it won't pull up any library no matter what I type in").

---

## Part 2 — Performance / UX

### 2.1 `Loading.js`: parallelize the startup query chain
The 14 queries ran strictly sequentially (each `enabled` by the previous one's success) —
14 round trips one after another, with 30–60 s timeouts each. Only three real data
dependencies exist:

```
user            → library_system + languages
linked_accounts → user + library_system
system_messages → library_system + library_location
everything else → catalog_status only
```

Queries now fan out in parallel once `catalog_status` confirms the server is reachable.
Wall-clock time drops from the *sum* of 14 round trips to roughly the *max* of them.
The final navigation gate now waits on **all** query success flags (previously the last link
of the chain implied the rest, which no longer holds). `setProgress` uses functional updates —
the old `progress + (100/numSteps)` closure lost increments when callbacks landed in the same
render batch.

### 2.2 Boot-critical timeout
New `GLOBALS.timeoutBoot = 8000`, used by `checkCachedUrl`. Previously 30 s + retry ≈ 60 s of
splash screen before anything happened when the server was slow/unreachable (matches the
"takes 30–60 seconds to open" review — that number is exactly the old timeout math).

### 2.3 OTA update polling: 10 s → 15 min
`Updates.checkForUpdateAsync()` ran on a **10-second** interval for the lifetime of the app,
and a found update triggered `Updates.reloadAsync()` mid-session — the app reloading out from
under a patron reads as a random crash/black screen ("came up but then goes to black screen,
then I see an update…").

### 2.4 `logging.js` `getErrorMessage`: accept both calling conventions
The signature is object-destructuring, but ~80 call sites pass positional args
`getErrorMessage(code, problem)` — every one of them silently discarded its arguments, so
users always saw the generic "An unexpected error occurred". Commit 96a19d3 (DIS-2539)
converted exactly one of these call sites to object form; this change instead makes the
function accept **both** forms, fixing all ~80 sites at once while remaining compatible with
past and future per-site conversions.

### 2.5 `theme.js`: use the cached theme on boot
`saveTheme()` wrote palettes to AsyncStorage on every launch, but nothing ever read them —
every cold start blocked the splash screen on a network fetch. The boot path now uses the
cached palettes instantly and refreshes the cache in the background (worst case the theme is
one launch behind the server).

### 2.6 `App.js`: schedule the API-log purge
`purgeExpiredApiErrorLogs()` existed but was never called; the `api_error_logs` table grew
without bound (one row per API error), slowing the write that sits on the request path. Now
purged (24 h retention) after DB init, non-blocking.

---

## Testing evidence

All changed files pass an esbuild JSX parse check, and the patch was runtime-verified on an
Android emulator (Pixel 7 AVD, API 35, Expo dev client built from this tree) in three stages.

### Stage 1 — hostile boot: fresh install, unreachable server

Configured against a guaranteed-unresolvable host (`.invalid` TLD), cold start on a fresh
install (empty AsyncStorage/SQLite — worst case for the migration race):

- Boot breadcrumbs ran 1→7: SQLite migration applied, theme fell back to the backup palette,
  splash resolved to the UI.
- All boot-time network failures (greenhouse, getAppSettings, getThemeInfo) were caught and
  logged; none escaped as a rejected promise.
- End state: the standard "Unable to establish connection with library. Please try again
  later." screen **in under a minute**. For comparison, a Play Store review (Dec 2025,
  v25.09.00) reports reaching this same screen only "after several minutes" — and on
  unpatched 26.06 this scenario can hang indefinitely instead.

### Stage 2 — full happy path against a live Aspen Discovery 26.06.01 (Koha ILS)

Against a real Aspen 26.06.01 test server: greenhouse `getLibrary` (12 libraries) →
"Find Your Library" search and select → login form with library-configured labels → patron
login → **the parallelized Loading chain** → Discover home with live browse categories and
cover images → holds/checkouts/lists/profile fetching normally → Library Card screen
(both the barcode and no-barcode-style variants render correctly).

### Stage 3 — regression tests reproducing the store-review failure modes

The ILS-side Apache was stopped and restarted while a logged-in session existed on-device:

| Step | Unpatched behavior | Patched behavior (observed) |
|---|---|---|
| Server down, cold app launch with cached session | `checkCachedUrl` fails → `RemoveData` + `SIGN_OUT` destroy the session before any UI renders; patron must re-find library + re-enter barcode (top review complaint: "about 50% of the time it would require searching for our library and re-inputting the library card number") | Log: `Could not verify library connection (transient network issue); keeping session.` Patron sees a specific dialog: "Unable to determine catalog status — Unable to connect to the server. Please verify your internet connection." (specific text = the getErrorMessage fix; previously always the generic "An unexpected error occurred") |
| Server restored, cold relaunch | Patron is at the login screen | **Straight into Discover, still authenticated — zero re-entry** |

The transient-vs-fatal distinction only skips logout for TIMEOUT/CONNECTION/NETWORK problems;
a genuinely invalid/dead library URL still signs out as before.

Suggested follow-up (not in this patch): the error dialog's single OK button (which proceeds
to logout, pre-existing behavior) could offer a Retry action alongside it.

## Deliberately not changed

- Per-query 30–60 s timeouts inside Loading.js (parallelism already reduces wall-clock to the
  max of the calls; tightening individual timeouts risks false failures on slow ILS backends).
- `queryClient.clear()` on every Loading-screen focus (defeats the 24 h staleTime — worth a
  product decision, not a drive-by change).
- `getErrorMessage` capturing to Sentry on every call in production (noisy, but changing it
  alters observability).

## References

- DIS-2413 — custom fetch client replacing axios/apisauce (26.06.00 release notes)
- DIS-2100 — SQLite API error log (26.06.00 release notes)
- DIS-2539 / commit 96a19d3 — prior partial fix for the `getErrorMessage` signature mismatch


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
