### PR TITLE
DIS-2672 parse getLibraries call properly

### DIFF
--- a/code/src/util/api/greenhouse.js
+++ b/code/src/util/api/greenhouse.js
@@ -137,7 +137,8 @@ export async function fetchAllLibrariesFromGreenhouse() {
      });
 
      if (response.ok) {
-          const libraries = [...(response.data.libraries ?? [])].sort((a, b) => {
+          const data = response.data?.result;
+          const libraries = [...(data.libraries ?? [])].sort((a, b) => {
                if (a.name !== b.name) return (a.name ?? '').localeCompare(b.name ?? '');
                return (a.librarySystem ?? '').localeCompare(b.librarySystem ?? '');
           });

--- a/release-notes/26.08.00.MD
+++ b/release-notes/26.08.00.MD
@@ -12,3 +12,5 @@
 - Ensure the progress bar loads smoothly even when updated rapidly. ([DIS-2526](https://aspen-discovery.atlassian.net/browse/DIS-2526)) (*MDN*)
 
 //imani
+- ensure we parse api result properly in fetchAllLibrariesFromGreenhouse accounting for result wrapper in JSON ([DIS-2672](https://aspen-discovery.atlassian.net/browse/DIS-2672)) (*IT*)
+


### PR DESCRIPTION
* set your slug in lida to something that starts with aspen-lida so it registers as community
* open LiDA
* click select your library
* you should see your list of libraries as you type in the box

