### PR TITLE
DIS-2697 Updated Login to not show select your library when user use…

### DIFF
--- a/code/src/screens/Auth/Login.js
+++ b/code/src/screens/Auth/Login.js
@@ -90,14 +90,9 @@ export const LoginScreen = () => {
                          if (result.success) {
                               setLibraries(result.libraries);
                               if (!result.shouldShowSelectLibrary) {
-                                   if (result.libraries.length == 1) {
-                                        setShowShouldSelectLibrary(result.shouldShowSelectLibrary);
-                                        logInfoMessage('Automatically selecting library ' + result.libraries[0].displayName + ' based on geolocation');
-                                        updateSelectedLibrary(result.libraries[0]);
-                                   }else{
-                                        logInfoMessage('Found ' + result.libraries.length + ' libraries, but shouldShowSelectLibrary is false');
-                                        setShowShouldSelectLibrary(true);
-                                   }
+                                   setShowShouldSelectLibrary(result.shouldShowSelectLibrary);
+                                   logInfoMessage('Automatically selecting library ' + result.libraries[0].displayName + ' based on geolocation');
+                                   updateSelectedLibrary(result.libraries[0]);
                               }else{
                                    logInfoMessage('Found ' + result.libraries.length + ' libraries');
                                    setShowShouldSelectLibrary(true);

--- a/release-notes/26.08.00.MD
+++ b/release-notes/26.08.00.MD
@@ -12,3 +12,5 @@
 - Ensure the progress bar loads smoothly even when updated rapidly. ([DIS-2526](https://aspen-discovery.atlassian.net/browse/DIS-2526)) (*MDN*)
 
 //imani
+### Other Updates
+- Remove code in Login.js overwriting Use User Home Location When Logging In preferences and causing show your library to show when not desired. ([DIS-2697](https://aspen-discovery.atlassian.net/browse/DIS-2697)) (*IT*)


### PR DESCRIPTION
* Open LiDA for a Library with Use User Home Location When Logging In checked and multiple locations selected in LiDA location settings
* select your library button should not show and instead the nearest location should be automatically selected.
