### PR TITLE
DIS-2703: add SearchGlobal.term as a default for storedTerm to avoid …

### DIFF
--- a/code/src/screens/Search/SearchResults.js
+++ b/code/src/screens/Search/SearchResults.js
@@ -49,7 +49,7 @@ export const SearchResults = () => {
      const navigation = useNavigation();
      const route = useRoute();
      const [page, setPage] = React.useState(1);
-     const [storedTerm, setStoredTerm] = React.useState('');
+     const [storedTerm, setStoredTerm] = React.useState(SearchGlobal.term);
      const { library } = React.useContext(LibrarySystemContext);
      const { language } = React.useContext(LanguageContext);
      const { scope } = React.useContext(LibraryBranchContext);

--- a/release-notes/26.08.00.MD
+++ b/release-notes/26.08.00.MD
@@ -12,3 +12,4 @@
 - Ensure the progress bar loads smoothly even when updated rapidly. ([DIS-2526](https://aspen-discovery.atlassian.net/browse/DIS-2526)) (*MDN*)
 
 //imani
+- add SearchGlobal.term as a default for storedTerm to avoid filters getting wiped out ([DIS-2703](https://aspen-discovery.atlassian.net/browse/DIS-2703)) (*IT*)


### PR DESCRIPTION
…filters getting wiped out

- Open LiDA
- search for a term
- open filters
- choose fiction
- the number of results should now shrink matching the number displayed for the filter
- search for a new term
- the filter should still be automatically cleared when a new term is searched